### PR TITLE
Run job from yaml

### DIFF
--- a/examples/db_usage.json
+++ b/examples/db_usage.json
@@ -1,0 +1,14 @@
+services:
+  - name: "main"
+    image: "ubuntu"
+
+  - name: "postgres-db"
+    image: "postgres"
+
+commands:
+  - directive: "export DB_HOSTNAME=postgres-db"
+  - directive: |
+      apt-get update
+      apt-get install -y postgresql-client
+  - directive: "createdb -h db -p 5432 -U postgres testdb3"
+  - directive: "echo Database testdb3 created"

--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,6 @@
 module github.com/renderedtext/agent
+
+require (
+	github.com/ghodss/yaml v1.0.0
+	gopkg.in/yaml.v2 v2.2.2
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,5 @@
+github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
+github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/job.go
+++ b/job.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/ghodss/yaml"
+)
+
+type Command struct {
+	Directive string `yaml:"directive"`
+}
+
+type Container struct {
+	Name  string `yaml:"name"`
+	Image string `yaml:"image"`
+}
+
+type Job struct {
+	Services []Container `yaml:"services"`
+	Commands []Command   `yaml:"commands"`
+}
+
+func check(e error) {
+	if e != nil {
+		panic(e)
+	}
+}
+
+func NewJobFromYaml(path string) (*Job, error) {
+	filename, _ := filepath.Abs(path)
+	yamlFile, err := ioutil.ReadFile(filename)
+
+	if err != nil {
+		return nil, err
+	}
+
+	var job Job
+
+	err = yaml.Unmarshal(yamlFile, &job)
+	if err != nil {
+		return nil, err
+	}
+
+	return &job, nil
+}
+
+func buildExecutor(services []Container) {
+	template := ""
+	template += `version: "2"` + "\n"
+	template += `services:` + "\n"
+
+	main := services[0]
+	template += `  ` + main.Name + ":\n"
+	template += `    image: "` + main.Image + `"` + "\n"
+
+	if len(services) > 1 {
+		template += `    links:` + "\n"
+
+		// first we add links
+		for _, c := range services[1:] {
+			template += `      - ` + c.Name + "\n"
+		}
+
+		// then we define the rest of the services
+		for _, c := range services[1:] {
+			template += `  ` + c.Name + ":\n"
+			template += `    image: "` + c.Image + `"` + "\n"
+		}
+	}
+
+	fmt.Println(template)
+
+	fmt.Println("* Creating docker-compose template")
+	err := ioutil.WriteFile("/tmp/dc1", []byte(template), 0644)
+	check(err)
+
+	cmd := exec.Command("bash", "-c", "docker-compose -f /tmp/dc1 build")
+
+	fmt.Println("* Starting docker compose")
+	err = cmd.Start()
+	check(err)
+
+	fmt.Println("* Waiting for build to finish")
+	err = cmd.Wait()
+	check(err)
+
+	fmt.Println("* Docker Compose Up")
+}
+
+func (job *Job) Run() {
+	buildExecutor(job.Services)
+
+	commands := []string{}
+	for _, c := range job.Commands {
+		commands = append(commands, c.Directive)
+	}
+
+	shell := NewShell()
+
+	shell.Run(commands, func(event interface{}) {
+		switch e := event.(type) {
+		case CommandStartedShellEvent:
+			fmt.Printf("command %d | Running: %s\n", e.CommandIndex, e.Command)
+		case CommandOutputShellEvent:
+			fmt.Printf("command %d | %s\n", e.CommandIndex, e.Output)
+		case CommandFinishedShellEvent:
+			fmt.Printf("command %d | exit status: %d\n", e.CommandIndex, e.ExitStatus)
+		default:
+			panic("Unknown shell event")
+		}
+	})
+}

--- a/main.go
+++ b/main.go
@@ -2,114 +2,16 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
-	"os/exec"
+	"os"
 )
 
-type Command struct {
-	Directive string
-}
-
-type Container struct {
-	Name  string
-	Image string
-}
-
-type Job struct {
-	Services []Container
-	Commands []Command
-	Epilogue []Command
-}
-
-func check(e error) {
-	if e != nil {
-		panic(e)
-	}
-}
-
-func buildExecutor(services []Container) {
-	template := ""
-	template += `version: "2"` + "\n"
-	template += `services:` + "\n"
-
-	main := services[0]
-	template += `  ` + main.Name + ":\n"
-	template += `    image: "` + main.Image + `"` + "\n"
-
-	if len(services) > 1 {
-		template += `    links:` + "\n"
-
-		// first we add links
-		for _, c := range services[1:] {
-			template += `      - ` + c.Name + "\n"
-		}
-
-		// then we define the rest of the services
-		for _, c := range services[1:] {
-			template += `  ` + c.Name + ":\n"
-			template += `    image: "` + c.Image + `"` + "\n"
-		}
-	}
-
-	fmt.Println(template)
-
-	fmt.Println("* Creating docker-compose template")
-	err := ioutil.WriteFile("/tmp/dc1", []byte(template), 0644)
-	check(err)
-
-	cmd := exec.Command("bash", "-c", "docker-compose -f /tmp/dc1 build")
-
-	fmt.Println("* Starting docker compose")
-	err = cmd.Start()
-	check(err)
-
-	fmt.Println("* Waiting for build to finish")
-	err = cmd.Wait()
-	check(err)
-
-	fmt.Println("* Docker Compose Up")
-}
-
-func run(job Job) {
-	buildExecutor(job.Services)
-
-	commands := []string{}
-	for _, c := range job.Commands {
-		commands = append(commands, c.Directive)
-	}
-
-	shell := NewShell()
-
-	shell.Run(commands, func(event interface{}) {
-		switch e := event.(type) {
-		case CommandStartedShellEvent:
-			fmt.Printf("command %d | Running: %s\n", e.CommandIndex, e.Command)
-		case CommandOutputShellEvent:
-			fmt.Printf("command %d | %s\n", e.CommandIndex, e.Output)
-		case CommandFinishedShellEvent:
-			fmt.Printf("command %d | exit status: %d\n", e.CommandIndex, e.ExitStatus)
-		default:
-			panic("Unknown shell event")
-		}
-	})
-}
-
 func main() {
-	j1 := Job{
-		Services: []Container{
-			Container{Name: "main", Image: "ubuntu"},
-			Container{Name: "db", Image: "postgres"},
-		},
-		Commands: []Command{
-			Command{Directive: "export DB_HOSTNAME=postgres-db"},
-			Command{Directive: `
-apt-get update
-apt-get install -y postgresql-client
-`},
-			Command{Directive: "createdb -h db -p 5432 -U postgres testdb3"},
-			Command{Directive: "echo Database testdb3 created"},
-		},
+	fmt.Printf(os.Args[1])
+	job, err := NewJobFromYaml(os.Args[1])
+
+	if err != nil {
+		panic(err)
 	}
 
-	run(j1)
+	job.Run()
 }


### PR DESCRIPTION
Reads in a YAML file job definition. Runs it.

The need for this comes from:

- Test out multiple types of jobs easily
- Preparation for acceptance tests for the Agent
- Makes prototyping easier, and documents examples