### PR TITLE
Pseudo terminal for output

### DIFF
--- a/examples/checkout.yaml
+++ b/examples/checkout.yaml
@@ -1,0 +1,10 @@
+services:
+  - name: "main"
+    image: "ubuntu"
+
+commands:
+  - directive: |
+      apt-get update
+      apt-get install -y git
+  - directive: "echo here"
+  - directive: "git clone https://github.com/renderedtext/cli.git"

--- a/go.mod
+++ b/go.mod
@@ -2,5 +2,6 @@ module github.com/renderedtext/agent
 
 require (
 	github.com/ghodss/yaml v1.0.0
+	github.com/kr/pty v1.1.3
 	gopkg.in/yaml.v2 v2.2.2
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
+github.com/kr/pty v1.1.3 h1:/Um6a/ZmD5tF7peoOJ5oN5KMQ0DrGVQSXLNwyckutPk=
+github.com/kr/pty v1.1.3/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
With this change we are now able to collect progress information from git clone, docker pull, and other programs that expect a TTY interface.

Current limitations:

- No way to distinguish between Stdout and Stderr. Do we need this?
- Scanner has a buffer of 64 * 1024 bytes.
- Scanner reads lines, collecting long lines might cause an issue and in delay in the streaming. Needs to be tested.

---

Edit: This change also introduces colors in the output, and terminal sizes.
