### PR TITLE
Serve a Basic HTTP API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,5 @@
 run:
-	go run *.go $(JOB)
+	go run *.go run $(JOB)
+
+serve:
+	go run *.go serve

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/semaphoreci/agent
 
 require (
 	github.com/ghodss/yaml v1.0.0
+	github.com/gorilla/handlers v1.4.0
+	github.com/gorilla/mux v1.6.2
 	github.com/kr/pty v1.1.3
 	gopkg.in/yaml.v2 v2.2.2
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,9 @@
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
+github.com/gorilla/handlers v1.4.0 h1:XulKRWSQK5uChr4pEgSE4Tc/OcmnU9GJuSwdog/tZsA=
+github.com/gorilla/handlers v1.4.0/go.mod h1:Qkdc/uu4tH4g6mTK6auzZ766c4CA0Ng8+o/OAirnOIQ=
+github.com/gorilla/mux v1.6.2 h1:Pgr17XVTNXAk3q/r4CpKzC5xBM/qW1uVLV+IhRZpIIk=
+github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/kr/pty v1.1.3 h1:/Um6a/ZmD5tF7peoOJ5oN5KMQ0DrGVQSXLNwyckutPk=
 github.com/kr/pty v1.1.3/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/main.go
+++ b/main.go
@@ -1,15 +1,66 @@
 package main
 
 import (
+	"fmt"
+	"log"
+	"net/http"
 	"os"
+
+	"github.com/gorilla/handlers"
+	"github.com/gorilla/mux"
 )
 
+type Server struct {
+	Host string
+	Port int
+}
+
+func (s *Server) Serve() {
+	r := mux.NewRouter().StrictSlash(true)
+	address := fmt.Sprintf("%s:%d", s.Host, s.Port)
+
+	r.HandleFunc("/status", s.Status).Methods("GET")
+	r.HandleFunc("/run", s.Run).Methods("POST")
+	r.HandleFunc("/stop", s.Stop).Methods("POST")
+
+	loggedRouter := handlers.LoggingHandler(os.Stdout, r)
+
+	log.Fatal(http.ListenAndServe(address, loggedRouter))
+}
+
+func (s *Server) Status(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(400)
+	fmt.Fprintf(w, `{"state": "waiting for job", "uptime": "pretty long time"}`)
+}
+
+func (s *Server) Run(w http.ResponseWriter, r *http.Request) {
+	s.unsuported(w)
+}
+
+func (s *Server) Stop(w http.ResponseWriter, r *http.Request) {
+	s.unsuported(w)
+}
+
+func (s *Server) unsuported(w http.ResponseWriter) {
+	w.WriteHeader(400)
+	fmt.Fprintf(w, `{"message": "not supported"}`)
+}
+
 func main() {
-	job, err := NewJobFromYaml(os.Args[1])
+	action := os.Args[1]
 
-	if err != nil {
-		panic(err)
+	switch action {
+	case "serve":
+		server := Server{Host: "0.0.0.0", Port: 8000}
+		server.Serve()
+
+	case "run":
+		job, err := NewJobFromYaml(os.Args[2])
+
+		if err != nil {
+			panic(err)
+		}
+
+		job.Run()
 	}
-
-	job.Run()
 }


### PR DESCRIPTION
To start an agent, run:

```
agent serve
```

To run a job from a file, run:

```
agent run <path-to-file>
```