### PR TITLE
Provide job logs via /jobs/<id>/log

### DIFF
--- a/examples/hello_world.yaml
+++ b/examples/hello_world.yaml
@@ -16,5 +16,5 @@ epilogue_commands:
   - directive: "echo 'hello world'"
 
 callbacks:
-  started: "http://httpstat.us/200"
-  finished: "http://httpstat.us/200"
+  started: "https://httpbin.org/status/200"
+  finished: "https://httpbin.org/status/200"

--- a/job.go
+++ b/job.go
@@ -2,10 +2,13 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/ghodss/yaml"
 )
@@ -70,24 +73,109 @@ func NewJobFromYaml(path string) (*Job, error) {
 func (job *Job) Run() {
 	fmt.Printf("%+v\n", job.Request)
 
+	os.RemoveAll("/tmp/run/semaphore/logs")
+	os.MkdirAll("/tmp/run/semaphore/logs", os.ModePerm)
+
+	// TODO: find better place for this
+	logfile, err := os.Create("/tmp/job_log.json")
+	if err != nil {
+		fmt.Printf("aaaa")
+		panic(err)
+	}
+
+	defer logfile.Close()
+
 	job.SendStartedCallback()
+
+	LogJobStart(logfile)
 
 	shell := NewShell()
 
 	shell.Run(job.Request, func(event interface{}) {
 		switch e := event.(type) {
 		case CommandStartedShellEvent:
-			fmt.Printf("command %d | Running: %s\n", e.CommandIndex, e.Command)
+			fmt.Printf("aaa")
+			LogCmdStarted(logfile, e.Timestamp, e.Directive)
 		case CommandOutputShellEvent:
-			fmt.Printf("command %d | %s\n", e.CommandIndex, e.Output)
+			fmt.Printf("bbb")
+			LogCmdOutput(logfile, e.Timestamp, e.Output)
 		case CommandFinishedShellEvent:
-			fmt.Printf("command %d | exit status: %d\n", e.CommandIndex, e.ExitStatus)
+			fmt.Printf("ccc")
+			LogCmdFinished(logfile, e.Timestamp, e.Directive, e.ExitStatus)
 		default:
 			panic("Unknown shell event")
 		}
 	})
 
+	logfile.Sync()
+
 	job.SendFinishedCallback("passed")
+
+	LogJobFinish(logfile, "passed")
+}
+
+func LogJobStart(logfile *os.File) {
+	m := make(map[string]interface{})
+
+	m["event"] = "job_started"
+	m["timestamp"] = int(time.Now().Unix())
+
+	jsonString, _ := json.Marshal(m)
+
+	logfile.Write([]byte(jsonString))
+	logfile.Write([]byte("\n"))
+}
+
+func LogJobFinish(logfile *os.File, result string) {
+	m := make(map[string]interface{})
+
+	m["event"] = "job_finished"
+	m["timestamp"] = int(time.Now().Unix())
+
+	jsonString, _ := json.Marshal(m)
+
+	logfile.Write([]byte(jsonString))
+	logfile.Write([]byte("\n"))
+}
+
+func LogCmdStarted(logfile *os.File, timestamp int, directive string) {
+	m := make(map[string]interface{})
+
+	m["event"] = "cmd_started"
+	m["timestamp"] = timestamp
+	m["directive"] = directive
+
+	jsonString, _ := json.Marshal(m)
+
+	logfile.Write([]byte(jsonString))
+	logfile.Write([]byte("\n"))
+}
+
+func LogCmdOutput(logfile *os.File, timestamp int, output string) {
+	m := make(map[string]interface{})
+
+	m["event"] = "cmd_output"
+	m["timestamp"] = timestamp
+	m["output"] = output
+
+	jsonString, _ := json.Marshal(m)
+
+	logfile.Write([]byte(jsonString))
+	logfile.Write([]byte("\n"))
+}
+
+func LogCmdFinished(logfile *os.File, timestamp int, directive string, exitStatus int) {
+	m := make(map[string]interface{})
+
+	m["event"] = "cmd_finished"
+	m["timestamp"] = timestamp
+	m["directive"] = directive
+	m["exit_status"] = exitStatus
+
+	jsonString, _ := json.Marshal(m)
+
+	logfile.Write([]byte(jsonString))
+	logfile.Write([]byte("\n"))
 }
 
 func (job *Job) SendStartedCallback() error {

--- a/job.go
+++ b/job.go
@@ -79,7 +79,6 @@ func (job *Job) Run() {
 	// TODO: find better place for this
 	logfile, err := os.Create("/tmp/job_log.json")
 	if err != nil {
-		fmt.Printf("aaaa")
 		panic(err)
 	}
 
@@ -94,13 +93,10 @@ func (job *Job) Run() {
 	shell.Run(job.Request, func(event interface{}) {
 		switch e := event.(type) {
 		case CommandStartedShellEvent:
-			fmt.Printf("aaa")
 			LogCmdStarted(logfile, e.Timestamp, e.Directive)
 		case CommandOutputShellEvent:
-			fmt.Printf("bbb")
 			LogCmdOutput(logfile, e.Timestamp, e.Output)
 		case CommandFinishedShellEvent:
-			fmt.Printf("ccc")
 			LogCmdFinished(logfile, e.Timestamp, e.Directive, e.ExitStatus)
 		default:
 			panic("Unknown shell event")

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"log"
 	"net/http"
 	"os"
@@ -24,6 +25,7 @@ func (s *Server) Serve() {
 	r.HandleFunc("/status", s.Status).Methods("GET")
 	r.HandleFunc("/jobs", s.Run).Methods("POST")
 	r.HandleFunc("/stop", s.Stop).Methods("POST")
+	r.HandleFunc("/jobs/{job_id}/log", s.Logs).Methods("GET")
 
 	loggedRouter := handlers.LoggingHandler(os.Stdout, r)
 
@@ -33,6 +35,23 @@ func (s *Server) Serve() {
 func (s *Server) Status(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(400)
 	fmt.Fprintf(w, `{"state": "%s", "uptime": "pretty long time"}`, s.State)
+}
+
+func (s *Server) Logs(w http.ResponseWriter, r *http.Request) {
+	w.Header().Add("Content-Type", "text/plain")
+
+	// not yet supported
+	// start_from = params[:start_from].to_i || 0
+
+	logfile, err := os.Open("/tmp/job_log.json")
+
+	if err != nil {
+		w.WriteHeader(404)
+		return
+	}
+	defer logfile.Close()
+
+	io.Copy(w, logfile)
 }
 
 func (s *Server) Run(w http.ResponseWriter, r *http.Request) {

--- a/shell.go
+++ b/shell.go
@@ -28,7 +28,7 @@ type ShellStreamHandler func(interface{})
 type CommandStartedShellEvent struct {
 	Timestamp    int
 	CommandIndex int
-	Command      string
+	Directive    string
 }
 
 type CommandOutputShellEvent struct {
@@ -42,6 +42,7 @@ type CommandFinishedShellEvent struct {
 	CommandIndex int
 	ExitStatus   int
 	Duration     int
+	Directive    string
 }
 
 func NewShell() Shell {
@@ -74,7 +75,7 @@ func (s *Shell) Run(jobRequest JobRequest, handler ShellStreamHandler) error {
 				handler(CommandStartedShellEvent{
 					Timestamp:    int(time.Now().Unix()),
 					CommandIndex: s.currentlyRunningCommandIndex,
-					Command:      jobRequest.Commands[s.currentlyRunningCommandIndex].Directive,
+					Directive:    jobRequest.Commands[s.currentlyRunningCommandIndex].Directive,
 				})
 			} else if match := s.commandEndRegex.FindStringSubmatch(text); len(match) == 2 {
 				// command finished
@@ -89,6 +90,7 @@ func (s *Shell) Run(jobRequest JobRequest, handler ShellStreamHandler) error {
 					CommandIndex: s.currentlyRunningCommandIndex,
 					ExitStatus:   exitStatus,
 					Duration:     0,
+					Directive:    jobRequest.Commands[s.currentlyRunningCommandIndex].Directive,
 				})
 
 				s.currentlyRunningCommandIndex += 1


### PR DESCRIPTION
Save logs to a local file, stream them via API.

Things that need to be improved in the future:

- better local path for the file, current is /tmp/job_log.json
- cleanup of the file
- a unified interface for accessing logs in the code