### PR TITLE
Enter teardown phase immiditely after job stop

### DIFF
--- a/pkg/jobs/lock.go
+++ b/pkg/jobs/lock.go
@@ -1,0 +1,27 @@
+package jobs
+
+import "sync/atomic"
+
+//
+// The sync/Mutex library only offers blocking Lock/Unlock mechanisms.
+//
+// We are rolling our own non-blocking lock.
+//
+// Usage:
+//
+//  l := Lock()
+//
+//  if l.TryLock() {
+//     fmt.Printf("In the lock")
+//  } else {
+//     fmt.Printf("Failed to acquire lock")
+//  }
+//
+
+type Lock struct {
+	state int32 // zero state of int32 variables in Go is 0
+}
+
+func (l *Lock) TryLock() bool {
+	return atomic.CompareAndSwapInt32(&l.state, 0, 1)
+}

--- a/pkg/jobs/panics.go
+++ b/pkg/jobs/panics.go
@@ -1,0 +1,13 @@
+package jobs
+
+import "fmt"
+
+func PreventPanicPropagation(callback func()) {
+	defer func() {
+		if r := recover(); r != nil {
+			fmt.Println("[panic] Prevented panic propagation.", r)
+		}
+	}()
+
+	callback()
+}

--- a/test/e2e/docker/job_stopping.rb
+++ b/test/e2e/docker/job_stopping.rb
@@ -23,7 +23,7 @@ start_job <<-JSON
     "files": [],
 
     "commands": [
-      { "directive": "sleep 10" },
+      { "directive": "sleep infinity" },
       { "directive": "echo 'here'" }
     ],
 
@@ -36,7 +36,7 @@ start_job <<-JSON
   }
 JSON
 
-wait_for_command_to_start("sleep 10")
+wait_for_command_to_start("sleep infinity")
 
 sleep 1
 
@@ -55,7 +55,7 @@ assert_job_log <<-LOG
   {"event":"cmd_finished", "timestamp":"*", "directive":"Exporting environment variables","exit_code":0,"finished_at":"*","started_at":"*"}
   {"event":"cmd_started",  "timestamp":"*", "directive":"Injecting Files"}
   {"event":"cmd_finished", "timestamp":"*", "directive":"Injecting Files","exit_code":0,"finished_at":"*","started_at":"*"}
-  {"event":"cmd_started",  "timestamp":"*", "directive":"sleep 10"}
-  {"event":"cmd_finished", "timestamp":"*", "directive":"sleep 10","exit_code":1,"finished_at":"*","started_at":"*"}
-  {"event":"job_finished", "timestamp":"*", "result":"failed"}
+  {"event":"cmd_started",  "timestamp":"*", "directive":"sleep infinity"}
+  {"event":"cmd_finished", "timestamp":"*", "directive":"sleep infinity","exit_code":1,"finished_at":"*","started_at":"*"}
+  {"event":"job_finished", "timestamp":"*", "result":"stopped"}
 LOG

--- a/test/e2e/shell/job_stopping.rb
+++ b/test/e2e/shell/job_stopping.rb
@@ -12,7 +12,7 @@ start_job <<-JSON
     "files": [],
 
     "commands": [
-      { "directive": "sleep 10" },
+      { "directive": "sleep infinity" },
       { "directive": "echo 'here'" }
     ],
 
@@ -25,7 +25,7 @@ start_job <<-JSON
   }
 JSON
 
-wait_for_command_to_start("sleep 10")
+wait_for_command_to_start("sleep infinity")
 
 sleep 1
 
@@ -39,7 +39,7 @@ assert_job_log <<-LOG
   {"event":"cmd_finished", "timestamp":"*", "directive":"Exporting environment variables","exit_code":0,"finished_at":"*","started_at":"*"}
   {"event":"cmd_started",  "timestamp":"*", "directive":"Injecting Files"}
   {"event":"cmd_finished", "timestamp":"*", "directive":"Injecting Files","exit_code":0,"finished_at":"*","started_at":"*"}
-  {"event":"cmd_started",  "timestamp":"*", "directive":"sleep 10"}
-  {"event":"cmd_finished", "timestamp":"*", "directive":"sleep 10","exit_code":1,"finished_at":"*","started_at":"*"}
-  {"event":"job_finished", "timestamp":"*", "result":"failed"}
+  {"event":"cmd_started",  "timestamp":"*", "directive":"sleep infinity"}
+  {"event":"cmd_finished", "timestamp":"*", "directive":"sleep infinity","exit_code":1,"finished_at":"*","started_at":"*"}
+  {"event":"job_finished", "timestamp":"*", "result":"stopped"}
 LOG


### PR DESCRIPTION
Takes care of the following issues:

- The job was stopped but its process is not stopped cleanly. In this case, we are giving back control to agent orchestrator (with the callbacks) that can do a hard-kill on the VM level.
 
- The job was stopped before the terminal was available for the Job. This can happen if the stop signal arrives when the Docker is booting up.

The algorithm introduces a new re-entrant lock for making sure that only one Teardown phase is active at any given time.

fixes https://github.com/renderedtext/issues/issues/2162