### PR TITLE
Preventing cutting unicode characters in half

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -27,8 +27,7 @@ blocks:
             - make test
 
   - name: "Shell Executor E2E tests"
-    dependencies:
-      - "Tests"
+    dependencies: []
     task:
       env_vars:
         - name: GO111MODULE
@@ -49,61 +48,27 @@ blocks:
           - docker exec -ti agent cat /tmp/agent_log
 
       jobs:
-        - name: Hello World
+        - name: Shell
           commands:
-            - make e2e TEST=shell/hello_world
+            - "make e2e TEST=shell/$TEST"
+          matrix:
+            - env_var: TEST
+              values:
+                - env_vars
+                - failed_job
+                - job_stopping
+                - file_injection
+                - file_injection_broken_file_mode
+                - stty_restoration
+                - epilogue_on_pass
+                - epilogue_on_fail
+                - ssh_jump_points
+                - unicode
+                - unknown_command
+                - broken_unicode
 
-        - name: Env Vars
-          commands:
-            - make e2e TEST=shell/env_vars
-
-        - name: Failed Job
-          commands:
-            - make e2e TEST=shell/failed_job
-
-        - name: Job Stopping
-          commands:
-            - make e2e TEST=shell/job_stopping
-
-        - name: File Injection
-          commands:
-            - make e2e TEST=shell/file_injection
-
-        - name: File Injection Broken File Mode
-          commands:
-            - make e2e TEST=shell/file_injection_broken_file_mode
-
-        - name: Stty Restoration
-          commands:
-            - make e2e TEST=shell/stty_restoration
-
-        - name: Epilogue On Pass
-          commands:
-            - make e2e TEST=shell/epilogue_on_pass
-
-        - name: Epilogue On Fail
-          commands:
-            - make e2e TEST=shell/epilogue_on_fail
-
-        - name: SSH Jump Point
-          commands:
-            - make e2e TEST=shell/ssh_jump_points
-
-        - name: "Unicode"
-          commands:
-            - make e2e TEST=shell/unicode
-
-        - name: "Unknown Command"
-          commands:
-            - make e2e TEST=shell/unknown_command
-
-        - name: "Broken Unicode"
-          commands:
-            - make e2e TEST=shell/broken_unicode
-
-  - name: "Docker Executor E2E tests"
-    dependencies:
-      - "Tests"
+  - name: "Docker Executor E2E"
+    dependencies: []
     task:
       secrets:
         - name: aws-ecr-payground
@@ -117,6 +82,8 @@ blocks:
 
       prologue:
         commands:
+          - sudo rm /etc/docker/daemon.json
+          - sudo service docker restart
           - sem-version go 1.11
           - checkout
           - go version
@@ -128,105 +95,37 @@ blocks:
           - docker exec -ti agent cat /tmp/agent_log
 
       jobs:
-        - name: Hello World
+        - name: Docker
           commands:
-            - make e2e TEST=docker/hello_world
-
-        - name: Env Vars
-          commands:
-            - make e2e TEST=docker/env_vars
-
-        - name: Failed Job
-          commands:
-            - make e2e TEST=docker/failed_job
-
-        - name: Job Stopping
-          commands:
-            - make e2e TEST=docker/job_stopping
-
-        - name: File Injection
-          commands:
-            - make e2e TEST=docker/file_injection
-
-        - name: File Injection Broken File Mode
-          commands:
-            - make e2e TEST=docker/file_injection_broken_file_mode
-
-        - name: Stty Restoration
-          commands:
-            - make e2e TEST=docker/stty_restoration
-
-        - name: Epilogue On Pass
-          commands:
-            - make e2e TEST=docker/epilogue_on_pass
-
-        - name: Epilogue On Fail
-          commands:
-            - make e2e TEST=docker/epilogue_on_fail
-
-        - name: Docker In Docker
-          commands:
-            - make e2e TEST=docker/docker_in_docker
-
-        - name: Container Env Vars
-          commands:
-            - make e2e TEST=docker/container_env_vars
-
-        - name: DockerHub Login
-          commands:
-            - make e2e TEST=docker/dockerhub_private_image
-
-        - name: DockerRegistry Login
-          commands:
-            - make e2e TEST=docker/docker_registry_private_image
-
-        - name: ECR Login
-          commands:
-            - make e2e TEST=docker/docker_private_image_ecr
-
-        - name: GCR Login
-          commands:
-            - make e2e TEST=docker/docker_private_image_gcr
-
-        - name: DockerHub Login Failed
-          commands:
-            - make e2e TEST=docker/dockerhub_private_image_bad_creds
-
-        - name: DockerRegistry Login Failed
-          commands:
-            - make e2e TEST=docker/docker_registry_private_image_bad_creds
-
-        - name: ECR Login Failed
-          commands:
-            - make e2e TEST=docker/docker_private_image_ecr_bad_creds
-
-        - name: GCR Login Failed
-          commands:
-            - make e2e TEST=docker/docker_private_image_gcr_bad_creds
-
-        - name: SSH Jump Point
-          commands:
-            - make e2e TEST=docker/ssh_jump_points
-
-        - name: "No Bash"
-          commands:
-            - make e2e TEST=docker/no_bash
-
-        - name: "Container custom name"
-          commands:
-            - make e2e TEST=docker/container_custom_name
-
-        - name: "Unicode"
-          commands:
-            - make e2e TEST=docker/unicode
-
-        - name: "Unknown Command"
-          commands:
-            - make e2e TEST=docker/unknown_command
-
-        - name: "Broken Unicode"
-          commands:
-            - make e2e TEST=docker/broken_unicode
+            - "make e2e TEST=docker/$TEST"
+          matrix:
+            - env_var: TEST
+              values:
+                - hello_world
+                - env_vars
+                - failed_job
+                - job_stopping
+                - file_injection
+                - file_injection_broken_file_mode
+                - stty_restoration
+                - epilogue_on_pass
+                - epilogue_on_fail
+                - docker_in_docker
+                - container_env_vars
+                - dockerhub_private_image
+                - docker_registry_private_image
+                - docker_private_image_ecr
+                - docker_private_image_gcr
+                - dockerhub_private_image_bad_creds
+                - docker_registry_private_image_bad_creds
+                - docker_private_image_ecr_bad_creds
+                - docker_private_image_gcr_bad_creds
+                - ssh_jump_points
+                - no_bash
+                - container_custom_name
+                - unicode
+                - unknown_command
+                - broken_unicode
 
 promotions:
   - name: Release

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -36,6 +36,8 @@ blocks:
 
       prologue:
         commands:
+          - sudo rm /etc/docker/daemon.json
+          - sudo service docker restart
           - sem-version go 1.11
           - checkout
           - go version
@@ -94,6 +96,10 @@ blocks:
         - name: "Unknown Command"
           commands:
             - make e2e TEST=shell/unknown_command
+
+        - name: "Broken Unicode"
+          commands:
+            - make e2e TEST=shell/broken_unicode
 
   - name: "Docker Executor E2E tests"
     dependencies:
@@ -217,6 +223,10 @@ blocks:
         - name: "Unknown Command"
           commands:
             - make e2e TEST=docker/unknown_command
+
+        - name: "Broken Unicode"
+          commands:
+            - make e2e TEST=docker/broken_unicode
 
 promotions:
   - name: Release

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -91,6 +91,10 @@ blocks:
           commands:
             - make e2e TEST=shell/unicode
 
+        - name: "Unknown Command"
+          commands:
+            - make e2e TEST=shell/unknown_command
+
   - name: "Docker Executor E2E tests"
     dependencies:
       - "Tests"
@@ -209,6 +213,10 @@ blocks:
         - name: "Unicode"
           commands:
             - make e2e TEST=docker/unicode
+
+        - name: "Unknown Command"
+          commands:
+            - make e2e TEST=docker/unknown_command
 
 promotions:
   - name: Release

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -87,6 +87,10 @@ blocks:
           commands:
             - make e2e TEST=shell/ssh_jump_points
 
+        - name: "Unicode"
+          commands:
+            - make e2e TEST=shell/unicode
+
   - name: "Docker Executor E2E tests"
     dependencies:
       - "Tests"
@@ -201,6 +205,10 @@ blocks:
         - name: "Container custom name"
           commands:
             - make e2e TEST=docker/container_custom_name
+
+        - name: "Unicode"
+          commands:
+            - make e2e TEST=docker/unicode
 
 promotions:
   - name: Release

--- a/pkg/shell/process.go
+++ b/pkg/shell/process.go
@@ -50,7 +50,7 @@ func NewProcess(cmd string, tempStoragePath string, shell io.Writer, tty *os.Fil
 		panic("Invalid TTY")
 	}
 
-	commandEndRegex := regexp.MustCompile(endMark + " " + `(\d)` + "[\r\n]+")
+	commandEndRegex := regexp.MustCompile(endMark + " " + `(\d+)` + "[\r\n]+")
 
 	return &Process{
 		Command:  cmd,
@@ -92,6 +92,9 @@ func (p *Process) StreamToStdout() {
 	// - If the UTF-8 sequence is complete. Cutting the UTF-8 sequence in half
 	//   leads to undefined (?) characters in the UI.
 	//
+
+	log.Println("Flushing to output started")
+	log.Println("Output buffer size", len(p.outputBuffer))
 
 	for len(p.outputBuffer) > 100 || time.Now().Sub(p.lastStream) > 100*time.Millisecond {
 		cutLength := 100

--- a/pkg/shell/process.go
+++ b/pkg/shell/process.go
@@ -110,10 +110,10 @@ func (p *Process) StreamToStdout() {
 		//
 		// An unicode sequence can't be longer than 4 bytes
 		//
-		unicodeContinuationMask := uint(1 << 8)
+		unicodeContinuationMask := uint(1 << 7)
 
 		for i := 0; i < 4; i++ {
-			if uint(p.outputBuffer[cutLength])&unicodeContinuationMask != unicodeContinuationMask {
+			if uint(p.outputBuffer[cutLength-1])&unicodeContinuationMask != unicodeContinuationMask {
 				break
 			}
 

--- a/test/e2e.rb
+++ b/test/e2e.rb
@@ -1,5 +1,7 @@
 # rubocop:disable all
 
+Encoding.default_external = Encoding::UTF_8
+
 require 'tempfile'
 require 'json'
 require 'timeout'

--- a/test/e2e/docker/broken_unicode.rb
+++ b/test/e2e/docker/broken_unicode.rb
@@ -10,6 +10,17 @@ start_job <<-JSON
   {
     "id": "#{$JOB_ID}",
 
+    "executor": "dockercompose",
+
+    "compose": {
+      "containers": [
+        {
+          "name": "main",
+          "image": "ruby:2.6"
+        }
+      ]
+    },
+
     "env_vars": [],
     "files": [],
 
@@ -30,6 +41,14 @@ wait_for_job_to_finish
 
 assert_job_log <<-LOG
   {"event":"job_started",  "timestamp":"*"}
+
+  {"event":"cmd_started",  "timestamp":"*", "directive":"Pulling docker images..."}
+  *** LONG_OUTPUT ***
+  {"event":"cmd_finished", "timestamp":"*", "directive":"Pulling docker images...","event":"cmd_finished","exit_code":0,"finished_at":"*","started_at":"*","timestamp":"*"}
+
+  {"event":"cmd_started",  "timestamp":"*", "directive":"Starting the docker image..."}
+  {"event":"cmd_output",   "timestamp":"*", "output":"Starting a new bash session.\\n"}
+  {"event":"cmd_finished", "timestamp":"*", "directive":"Starting the docker image...","event":"cmd_finished","exit_code":0,"finished_at":"*","started_at":"*","timestamp":"*"}
 
   {"event":"cmd_started",  "timestamp":"*", "directive":"Exporting environment variables"}
   {"event":"cmd_finished", "timestamp":"*", "directive":"Exporting environment variables","exit_code":0,"finished_at":"*","started_at":"*"}

--- a/test/e2e/docker/unicode.rb
+++ b/test/e2e/docker/unicode.rb
@@ -1,0 +1,60 @@
+#!/bin/ruby
+# rubocop:disable all
+
+require_relative '../../e2e'
+
+start_job <<-JSON
+  {
+    "id": "#{$JOB_ID}",
+
+    "executor": "dockercompose",
+
+    "compose": {
+      "containers": [
+        {
+          "name": "main",
+          "image": "ruby:2.6"
+        }
+      ]
+    },
+
+    "env_vars": [],
+
+    "files": [],
+
+    "commands": [
+      { "directive": "echo 特定の伝説に拠る物語の由来については諸説存在し。特定の伝説に拠る物語の由来については諸説存在し。特定の伝説に拠る物語の由来については諸説存在し。" }
+    ],
+
+    "epilogue_always_commands": [],
+
+    "callbacks": {
+      "finished": "https://httpbin.org/status/200",
+      "teardown_finished": "https://httpbin.org/status/200"
+    }
+  }
+JSON
+
+wait_for_job_to_finish
+
+assert_job_log <<-LOG
+  {"event":"job_started",  "timestamp":"*"}
+  {"event":"cmd_started",  "timestamp":"*", "directive":"Pulling docker images..."}
+  *** LONG_OUTPUT ***
+  {"event":"cmd_finished", "timestamp":"*", "directive":"Pulling docker images...","event":"cmd_finished","exit_code":0,"finished_at":"*","started_at":"*","timestamp":"*"}
+
+  {"event":"cmd_started",  "timestamp":"*", "directive":"Starting the docker image..."}
+  {"event":"cmd_output",   "timestamp":"*", "output":"Starting a new bash session.\\n"}
+  {"event":"cmd_finished", "timestamp":"*", "directive":"Starting the docker image...","event":"cmd_finished","exit_code":0,"finished_at":"*","started_at":"*","timestamp":"*"}
+
+  {"event":"cmd_started",  "timestamp":"*", "directive":"Exporting environment variables"}
+  {"event":"cmd_finished", "timestamp":"*", "directive":"Exporting environment variables","exit_code":0,"finished_at":"*","started_at":"*"}
+  {"event":"cmd_started",  "timestamp":"*", "directive":"Injecting Files"}
+  {"event":"cmd_finished", "timestamp":"*", "directive":"Injecting Files","exit_code":0,"finished_at":"*","started_at":"*"}
+  {"event":"cmd_started",  "timestamp":"*", "directive":"echo 特定の伝説に拠る物語の由来については諸説存在し。特定の伝説に拠る物語の由来については諸説存在し。特定の伝説に拠る物語の由来については諸説存在し。"}
+  {"event":"cmd_output",   "timestamp":"*", "output":"特定の伝説に拠る物語の由来については諸説存在し。特定の伝説に拠る物語の由来については諸説存在し。特定の伝説に拠る物語の由来については諸説存在し。\\n"}
+  {"event":"cmd_finished", "timestamp":"*", "directive":"echo 特定の伝説に拠る物語の由来については諸説存在し。","exit_code":0,"finished_at":"*","started_at":"*"}
+  {"event":"cmd_started",  "timestamp":"*", "directive":"export SEMAPHORE_JOB_RESULT=passed"}
+  {"event":"cmd_finished", "timestamp":"*", "directive":"export SEMAPHORE_JOB_RESULT=passed","exit_code":0,"finished_at":"*","started_at":"*"}
+  {"event":"job_finished", "timestamp":"*", "result":"passed"}
+LOG

--- a/test/e2e/docker/unicode.rb
+++ b/test/e2e/docker/unicode.rb
@@ -1,4 +1,7 @@
 #!/bin/ruby
+
+Encoding.default_external = Encoding::UTF_8
+
 # rubocop:disable all
 
 require_relative '../../e2e'
@@ -52,8 +55,12 @@ assert_job_log <<-LOG
   {"event":"cmd_started",  "timestamp":"*", "directive":"Injecting Files"}
   {"event":"cmd_finished", "timestamp":"*", "directive":"Injecting Files","exit_code":0,"finished_at":"*","started_at":"*"}
   {"event":"cmd_started",  "timestamp":"*", "directive":"echo 特定の伝説に拠る物語の由来については諸説存在し。特定の伝説に拠る物語の由来については諸説存在し。特定の伝説に拠る物語の由来については諸説存在し。"}
-  {"event":"cmd_output",   "timestamp":"*", "output":"特定の伝説に拠る物語の由来については諸説存在し。特定の伝説に拠る物語の由来については諸説存在し。特定の伝説に拠る物語の由来については諸説存在し。\\n"}
-  {"event":"cmd_finished", "timestamp":"*", "directive":"echo 特定の伝説に拠る物語の由来については諸説存在し。","exit_code":0,"finished_at":"*","started_at":"*"}
+
+  {"event":"cmd_output",   "timestamp":"*", "output":"特定の伝説に拠る物語の由来については諸説存在し。特定の伝説に拠る"}
+  {"event":"cmd_output",   "timestamp":"*", "output":"物語の由来については諸説存在し。特定の伝説に拠る物語の由来につい"}
+  {"event":"cmd_output",   "timestamp":"*", "output":"ては諸説存在し。\\n"}
+
+  {"event":"cmd_finished", "timestamp":"*", "directive":"echo 特定の伝説に拠る物語の由来については諸説存在し。特定の伝説に拠る物語の由来については諸説存在し。特定の伝説に拠る物語の由来については諸説存在し。","exit_code":0,"finished_at":"*","started_at":"*"}
   {"event":"cmd_started",  "timestamp":"*", "directive":"export SEMAPHORE_JOB_RESULT=passed"}
   {"event":"cmd_finished", "timestamp":"*", "directive":"export SEMAPHORE_JOB_RESULT=passed","exit_code":0,"finished_at":"*","started_at":"*"}
   {"event":"job_finished", "timestamp":"*", "result":"passed"}

--- a/test/e2e/docker/unknown_command.rb
+++ b/test/e2e/docker/unknown_command.rb
@@ -1,0 +1,62 @@
+#!/bin/ruby
+# rubocop:disable all
+
+require_relative '../../e2e'
+
+start_job <<-JSON
+  {
+    "id": "#{$JOB_ID}",
+
+    "executor": "dockercompose",
+
+    "compose": {
+      "containers": [
+        {
+          "name": "main",
+          "image": "ruby:2.6"
+        }
+      ]
+    },
+
+    "env_vars": [],
+
+    "files": [],
+
+    "commands": [
+      { "directive": "echhhho Hello World" }
+    ],
+
+    "epilogue_always_commands": [],
+
+    "callbacks": {
+      "finished": "https://httpbin.org/status/200",
+      "teardown_finished": "https://httpbin.org/status/200"
+    }
+  }
+JSON
+
+wait_for_job_to_finish
+
+assert_job_log <<-LOG
+  {"event":"job_started",  "timestamp":"*"}
+  {"event":"cmd_started",  "timestamp":"*", "directive":"Pulling docker images..."}
+  *** LONG_OUTPUT ***
+  {"event":"cmd_finished", "timestamp":"*", "directive":"Pulling docker images...","event":"cmd_finished","exit_code":0,"finished_at":"*","started_at":"*","timestamp":"*"}
+
+  {"event":"cmd_started",  "timestamp":"*", "directive":"Starting the docker image..."}
+  {"event":"cmd_output",   "timestamp":"*", "output":"Starting a new bash session.\\n"}
+  {"event":"cmd_finished", "timestamp":"*", "directive":"Starting the docker image...","event":"cmd_finished","exit_code":0,"finished_at":"*","started_at":"*","timestamp":"*"}
+
+  {"event":"cmd_started",  "timestamp":"*", "directive":"Exporting environment variables"}
+  {"event":"cmd_finished", "timestamp":"*", "directive":"Exporting environment variables","exit_code":0,"finished_at":"*","started_at":"*"}
+  {"event":"cmd_started",  "timestamp":"*", "directive":"Injecting Files"}
+  {"event":"cmd_finished", "timestamp":"*", "directive":"Injecting Files","exit_code":0,"finished_at":"*","started_at":"*"}
+
+  {"event":"cmd_started",  "timestamp":"*", "directive":"echhhho Hello World"}
+  {"event":"cmd_output",   "timestamp":"*", "output":"bash: echhhho: command not found\\n"}
+  {"event":"cmd_finished", "timestamp":"*", "directive":"echhhho Hello World","exit_code":127,"finished_at":"*","started_at":"*"}
+
+  {"event":"cmd_started",  "timestamp":"*", "directive":"export SEMAPHORE_JOB_RESULT=passed"}
+  {"event":"cmd_finished", "timestamp":"*", "directive":"export SEMAPHORE_JOB_RESULT=passed","exit_code":0,"finished_at":"*","started_at":"*"}
+  {"event":"job_finished", "timestamp":"*", "result":"passed"}
+LOG

--- a/test/e2e/docker/unknown_command.rb
+++ b/test/e2e/docker/unknown_command.rb
@@ -56,7 +56,7 @@ assert_job_log <<-LOG
   {"event":"cmd_output",   "timestamp":"*", "output":"bash: echhhho: command not found\\n"}
   {"event":"cmd_finished", "timestamp":"*", "directive":"echhhho Hello World","exit_code":127,"finished_at":"*","started_at":"*"}
 
-  {"event":"cmd_started",  "timestamp":"*", "directive":"export SEMAPHORE_JOB_RESULT=passed"}
-  {"event":"cmd_finished", "timestamp":"*", "directive":"export SEMAPHORE_JOB_RESULT=passed","exit_code":0,"finished_at":"*","started_at":"*"}
-  {"event":"job_finished", "timestamp":"*", "result":"passed"}
+  {"event":"cmd_started",  "timestamp":"*", "directive":"export SEMAPHORE_JOB_RESULT=failed"}
+  {"event":"cmd_finished", "timestamp":"*", "directive":"export SEMAPHORE_JOB_RESULT=failed","exit_code":0,"finished_at":"*","started_at":"*"}
+  {"event":"job_finished", "timestamp":"*", "result":"failed"}
 LOG

--- a/test/e2e/shell/broken_unicode.rb
+++ b/test/e2e/shell/broken_unicode.rb
@@ -1,0 +1,44 @@
+#!/bin/ruby
+
+Encoding.default_external = Encoding::UTF_8
+
+# rubocop:disable all
+
+require_relative '../../e2e'
+
+start_job <<-JSON
+  {
+    "id": "#{$JOB_ID}",
+
+    "env_vars": [],
+    "files": [],
+
+    "commands": [
+      { "directive": "awk '{ printf(\\\"%c%c%c%c%c\\\", 150, 150, 150, 150, 150) }'"}
+    ],
+
+    "epilogue_always_commands": [],
+
+    "callbacks": {
+      "finished": "https://httpbin.org/status/200",
+      "teardown_finished": "https://httpbin.org/status/200"
+    }
+  }
+JSON
+
+wait_for_job_to_finish
+
+assert_job_log <<-LOG
+  {"event":"job_started",  "timestamp":"*"}
+
+  {"event":"cmd_started",  "timestamp":"*", "directive":"Exporting environment variables"}
+  {"event":"cmd_finished", "timestamp":"*", "directive":"Exporting environment variables","exit_code":0,"finished_at":"*","started_at":"*"}
+  {"event":"cmd_started",  "timestamp":"*", "directive":"Injecting Files"}
+  {"event":"cmd_finished", "timestamp":"*", "directive":"Injecting Files","exit_code":0,"finished_at":"*","started_at":"*"}
+
+
+  {"event":"cmd_started",  "timestamp":"*", "directive":"export SEMAPHORE_JOB_RESULT=passed"}
+  {"event":"cmd_finished", "timestamp":"*", "directive":"export SEMAPHORE_JOB_RESULT=passed","exit_code":0,"finished_at":"*","started_at":"*"}
+
+  {"event":"job_finished", "timestamp":"*", "result":"passed"}
+LOG

--- a/test/e2e/shell/unicode.rb
+++ b/test/e2e/shell/unicode.rb
@@ -1,0 +1,67 @@
+#!/bin/ruby
+
+Encoding.default_external = Encoding::UTF_8
+
+# rubocop:disable all
+
+require_relative '../../e2e'
+
+start_job <<-JSON
+  {
+    "id": "#{$JOB_ID}",
+
+    "executor": "dockercompose",
+
+    "compose": {
+      "containers": [
+        {
+          "name": "main",
+          "image": "ruby:2.6"
+        }
+      ]
+    },
+
+    "env_vars": [],
+
+    "files": [],
+
+    "commands": [
+      { "directive": "echo 特定の伝説に拠る物語の由来については諸説存在し。特定の伝説に拠る物語の由来については諸説存在し。特定の伝説に拠る物語の由来については諸説存在し。" }
+    ],
+
+    "epilogue_always_commands": [],
+
+    "callbacks": {
+      "finished": "https://httpbin.org/status/200",
+      "teardown_finished": "https://httpbin.org/status/200"
+    }
+  }
+JSON
+
+wait_for_job_to_finish
+
+assert_job_log <<-LOG
+  {"event":"job_started",  "timestamp":"*"}
+  {"event":"cmd_started",  "timestamp":"*", "directive":"Pulling docker images..."}
+  *** LONG_OUTPUT ***
+  {"event":"cmd_finished", "timestamp":"*", "directive":"Pulling docker images...","event":"cmd_finished","exit_code":0,"finished_at":"*","started_at":"*","timestamp":"*"}
+
+  {"event":"cmd_started",  "timestamp":"*", "directive":"Starting the docker image..."}
+  {"event":"cmd_output",   "timestamp":"*", "output":"Starting a new bash session.\\n"}
+  {"event":"cmd_finished", "timestamp":"*", "directive":"Starting the docker image...","event":"cmd_finished","exit_code":0,"finished_at":"*","started_at":"*","timestamp":"*"}
+
+  {"event":"cmd_started",  "timestamp":"*", "directive":"Exporting environment variables"}
+  {"event":"cmd_finished", "timestamp":"*", "directive":"Exporting environment variables","exit_code":0,"finished_at":"*","started_at":"*"}
+  {"event":"cmd_started",  "timestamp":"*", "directive":"Injecting Files"}
+  {"event":"cmd_finished", "timestamp":"*", "directive":"Injecting Files","exit_code":0,"finished_at":"*","started_at":"*"}
+  {"event":"cmd_started",  "timestamp":"*", "directive":"echo 特定の伝説に拠る物語の由来については諸説存在し。特定の伝説に拠る物語の由来については諸説存在し。特定の伝説に拠る物語の由来については諸説存在し。"}
+
+  {"event":"cmd_output",   "timestamp":"*", "output":"特定の伝説に拠る物語の由来については諸説存在し。特定の伝説に拠る"}
+  {"event":"cmd_output",   "timestamp":"*", "output":"物語の由来については諸説存在し。特定の伝説に拠る物語の由来につい"}
+  {"event":"cmd_output",   "timestamp":"*", "output":"ては諸説存在し。\\n"}
+
+  {"event":"cmd_finished", "timestamp":"*", "directive":"echo 特定の伝説に拠る物語の由来については諸説存在し。特定の伝説に拠る物語の由来については諸説存在し。特定の伝説に拠る物語の由来については諸説存在し。","exit_code":0,"finished_at":"*","started_at":"*"}
+  {"event":"cmd_started",  "timestamp":"*", "directive":"export SEMAPHORE_JOB_RESULT=passed"}
+  {"event":"cmd_finished", "timestamp":"*", "directive":"export SEMAPHORE_JOB_RESULT=passed","exit_code":0,"finished_at":"*","started_at":"*"}
+  {"event":"job_finished", "timestamp":"*", "result":"passed"}
+LOG

--- a/test/e2e/shell/unicode.rb
+++ b/test/e2e/shell/unicode.rb
@@ -10,19 +10,7 @@ start_job <<-JSON
   {
     "id": "#{$JOB_ID}",
 
-    "executor": "dockercompose",
-
-    "compose": {
-      "containers": [
-        {
-          "name": "main",
-          "image": "ruby:2.6"
-        }
-      ]
-    },
-
     "env_vars": [],
-
     "files": [],
 
     "commands": [
@@ -42,18 +30,12 @@ wait_for_job_to_finish
 
 assert_job_log <<-LOG
   {"event":"job_started",  "timestamp":"*"}
-  {"event":"cmd_started",  "timestamp":"*", "directive":"Pulling docker images..."}
-  *** LONG_OUTPUT ***
-  {"event":"cmd_finished", "timestamp":"*", "directive":"Pulling docker images...","event":"cmd_finished","exit_code":0,"finished_at":"*","started_at":"*","timestamp":"*"}
-
-  {"event":"cmd_started",  "timestamp":"*", "directive":"Starting the docker image..."}
-  {"event":"cmd_output",   "timestamp":"*", "output":"Starting a new bash session.\\n"}
-  {"event":"cmd_finished", "timestamp":"*", "directive":"Starting the docker image...","event":"cmd_finished","exit_code":0,"finished_at":"*","started_at":"*","timestamp":"*"}
 
   {"event":"cmd_started",  "timestamp":"*", "directive":"Exporting environment variables"}
   {"event":"cmd_finished", "timestamp":"*", "directive":"Exporting environment variables","exit_code":0,"finished_at":"*","started_at":"*"}
   {"event":"cmd_started",  "timestamp":"*", "directive":"Injecting Files"}
   {"event":"cmd_finished", "timestamp":"*", "directive":"Injecting Files","exit_code":0,"finished_at":"*","started_at":"*"}
+
   {"event":"cmd_started",  "timestamp":"*", "directive":"echo 特定の伝説に拠る物語の由来については諸説存在し。特定の伝説に拠る物語の由来については諸説存在し。特定の伝説に拠る物語の由来については諸説存在し。"}
 
   {"event":"cmd_output",   "timestamp":"*", "output":"特定の伝説に拠る物語の由来については諸説存在し。特定の伝説に拠る"}
@@ -61,7 +43,9 @@ assert_job_log <<-LOG
   {"event":"cmd_output",   "timestamp":"*", "output":"ては諸説存在し。\\n"}
 
   {"event":"cmd_finished", "timestamp":"*", "directive":"echo 特定の伝説に拠る物語の由来については諸説存在し。特定の伝説に拠る物語の由来については諸説存在し。特定の伝説に拠る物語の由来については諸説存在し。","exit_code":0,"finished_at":"*","started_at":"*"}
+
   {"event":"cmd_started",  "timestamp":"*", "directive":"export SEMAPHORE_JOB_RESULT=passed"}
   {"event":"cmd_finished", "timestamp":"*", "directive":"export SEMAPHORE_JOB_RESULT=passed","exit_code":0,"finished_at":"*","started_at":"*"}
+
   {"event":"job_finished", "timestamp":"*", "result":"passed"}
 LOG

--- a/test/e2e/shell/unknown_command.rb
+++ b/test/e2e/shell/unknown_command.rb
@@ -1,0 +1,41 @@
+#!/bin/ruby
+# rubocop:disable all
+
+require_relative '../../e2e'
+
+start_job <<-JSON
+  {
+    "id": "#{$JOB_ID}",
+
+    "env_vars": [],
+
+    "files": [],
+
+    "commands": [
+      { "directive": "echhhho Hello World" }
+    ],
+
+    "epilogue_always_commands": [],
+
+    "callbacks": {
+      "finished": "https://httpbin.org/status/200",
+      "teardown_finished": "https://httpbin.org/status/200"
+    }
+  }
+JSON
+
+wait_for_job_to_finish
+
+assert_job_log <<-LOG
+  {"event":"job_started",  "timestamp":"*"}
+  {"event":"cmd_started",  "timestamp":"*", "directive":"Exporting environment variables"}
+  {"event":"cmd_finished", "timestamp":"*", "directive":"Exporting environment variables","exit_code":0,"finished_at":"*","started_at":"*"}
+  {"event":"cmd_started",  "timestamp":"*", "directive":"Injecting Files"}
+  {"event":"cmd_finished", "timestamp":"*", "directive":"Injecting Files","exit_code":0,"finished_at":"*","started_at":"*"}
+  {"event":"cmd_started",  "timestamp":"*", "directive":"echhhho Hello World"}
+  {"event":"cmd_output",   "timestamp":"*", "output":"bash: echhhho: command not found\\n"}
+  {"event":"cmd_finished", "timestamp":"*", "directive":"echhhho Hello World","exit_code":127,"finished_at":"*","started_at":"*"}
+  {"event":"cmd_started",  "timestamp":"*", "directive":"export SEMAPHORE_JOB_RESULT=failed"}
+  {"event":"cmd_finished", "timestamp":"*", "directive":"export SEMAPHORE_JOB_RESULT=failed","exit_code":0,"finished_at":"*","started_at":"*"}
+  {"event":"job_finished", "timestamp":"*", "result":"failed"}
+LOG


### PR DESCRIPTION
Now, that we are no longer waiting for the newline character to flush the output buffer, a new bug got introduced. We are cutting Unicode characters in-half.

Reminder. A UTF-8 character can span to up to 4 bytes. The highest bit in the (8th bit) marks if the character is finished or there is more upcoming information in the next byte.

Example:

A UTF-8 character spanning 3 bytes:

10101010 -> 10101010 -> 00101010

A UTF-8 character spanning 1 byte:

00101010