### PR TITLE
Fix timming issues in log buffers and UTF8 cutting

### DIFF
--- a/pkg/shell/output_buffer_test.go
+++ b/pkg/shell/output_buffer_test.go
@@ -36,7 +36,7 @@ func Test__OutputBuffer__SimpleAscii__ShorterThanMinimalCutLength(t *testing.T) 
 	// We need to wait a bit before flushing, the buffer is still too short
 	assert.Equal(t, ok, false)
 
-	time.Sleep(OutputBufferMaxTimeSinceLastFlush)
+	time.Sleep(OutputBufferMaxTimeSinceLastAppend)
 
 	flushed, ok = buffer.Flush()
 	assert.Equal(t, ok, true)
@@ -61,7 +61,7 @@ func Test__OutputBuffer__SimpleAscii__LongerThanMinimalCutLength(t *testing.T) {
 	assert.Equal(t, flushed1, string(input[:OutputBufferDefaultCutLength]))
 
 	// We need to wait a bit before flushing, the buffer is still too short
-	time.Sleep(OutputBufferMaxTimeSinceLastFlush)
+	time.Sleep(OutputBufferMaxTimeSinceLastAppend)
 
 	flushed2, ok := buffer.Flush()
 	assert.Equal(t, ok, true)
@@ -89,7 +89,7 @@ func Test__OutputBuffer__UTF8_Sequence__Simple(t *testing.T) {
 		if ok {
 			out += flushed
 		} else {
-			time.Sleep(OutputBufferMaxTimeSinceLastFlush)
+			time.Sleep(OutputBufferMaxTimeSinceLastAppend)
 		}
 	}
 
@@ -114,7 +114,7 @@ func Test__OutputBuffer__UTF8_Sequence__Short(t *testing.T) {
 		if ok {
 			out += flushed
 		} else {
-			time.Sleep(OutputBufferMaxTimeSinceLastFlush)
+			time.Sleep(OutputBufferMaxTimeSinceLastAppend)
 		}
 	}
 
@@ -142,9 +142,64 @@ func Test__OutputBuffer__InvalidUTF8_Sequence(t *testing.T) {
 		if ok {
 			out += flushed
 		} else {
-			time.Sleep(OutputBufferMaxTimeSinceLastFlush)
+			time.Sleep(OutputBufferMaxTimeSinceLastAppend)
 		}
 	}
 
+	assert.Equal(t, out, string(input))
+}
+
+func Test__OutputBuffer__FlushIgnoresCharactersThatAreNotUtf8Valid(t *testing.T) {
+	//
+	// We construct a 100 byte long string to enable a full flush.
+	//
+	// The first 99 bytes will come from the 3-byte long kanji character, while
+	// the last byte will be a broken character
+
+	buffer := NewOutputBuffer()
+
+	input := ""
+	for i := 0; i < 33; i++ {
+		input += "特"
+	}
+
+	nonUtf8Chars := []byte{[]byte("特")[0]}
+
+	// In total, we are inserting 100 bytes
+	buffer.Append([]byte(input))
+	buffer.Append(nonUtf8Chars)
+
+	// In the output, we expect that the last broken byte is not returned.
+
+	out, ok := buffer.Flush()
+
+	assert.Equal(t, ok, true)
+	assert.Equal(t, out, input)
+}
+
+func Test__OutputBuffer__FlushReturnsBytesThatAreBrokenAndSitInTheBufferForTooLong(t *testing.T) {
+	//
+	// We construct a 100 byte long string to enable a full flush.
+	//
+	// The first 99 bytes will come from the 3-byte long kanji character, while
+	// the last byte will be a broken character
+	//
+
+	buffer := NewOutputBuffer()
+
+	input := []byte{}
+	for i := 0; i < 33; i++ {
+		input = append(input, []byte("特")...)
+	}
+	input = append(input, []byte("特")[0])
+
+	buffer.Append(input)
+
+	// We wait for a while, and let the broken become bocome stale.
+	// Stale characters are forced out of the buffer, even if they are not valid.
+	time.Sleep(200 * time.Millisecond)
+
+	out, ok := buffer.Flush()
+	assert.Equal(t, ok, true)
 	assert.Equal(t, out, string(input))
 }


### PR DESCRIPTION
Previously, we were using the `lastFlush` timestamp to determine if a broken utf-8 character is stale in the bufffer. This, however, caused a bug that prematurely flushed the broken characters, even if they weren't in the buffer long enough.

This could be reproduced with enough tries by doing `sleep 0.2 && echo "特"`.

---

In the new implemetation, we have switched to using `lastAppend` to determine if the last bytes in the buffer are ready to be flushed.