### PR TITLE
Introduce command aliases

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -52,6 +52,7 @@ blocks:
           matrix:
             - env_var: TEST
               values:
+                - command_aliases
                 - env_vars
                 - failed_job
                 - job_stopping
@@ -98,6 +99,7 @@ blocks:
             - env_var: TEST
               values:
                 - hello_world
+                - command_aliases
                 - env_vars
                 - failed_job
                 - job_stopping

--- a/pkg/api/job_request.go
+++ b/pkg/api/job_request.go
@@ -31,6 +31,7 @@ type Compose struct {
 
 type Command struct {
 	Directive string `json:"directive" yaml:"directive"`
+	Alias     string `json:"alias" yaml:"alias"`
 }
 
 type EnvVar struct {

--- a/pkg/executors/docker_compose_executor_test.go
+++ b/pkg/executors/docker_compose_executor_test.go
@@ -64,21 +64,21 @@ func startComposeExecutor() (*DockerComposeExecutor, *eventlogger.Logger, *event
 func Test__DockerComposeExecutor(t *testing.T) {
 	e, _, testLoggerBackend := startComposeExecutor()
 
-	e.RunCommand("echo 'here'", false)
+	e.RunCommand("echo 'here'", false, "")
 
 	multilineCmd := `
 	  if [ -d /etc ]; then
 	    echo 'etc exists, multiline huzzahh!'
 	  fi
 	`
-	e.RunCommand(multilineCmd, false)
+	e.RunCommand(multilineCmd, false, "")
 
 	envVars := []api.EnvVar{
 		api.EnvVar{Name: "A", Value: "Zm9vCg=="},
 	}
 
 	e.ExportEnvVars(envVars)
-	e.RunCommand("echo $A", false)
+	e.RunCommand("echo $A", false, "")
 
 	files := []api.File{
 		api.File{
@@ -89,9 +89,9 @@ func Test__DockerComposeExecutor(t *testing.T) {
 	}
 
 	e.InjectFiles(files)
-	e.RunCommand("cat /tmp/random-file.txt", false)
+	e.RunCommand("cat /tmp/random-file.txt", false, "")
 
-	e.RunCommand("echo $?", false)
+	e.RunCommand("echo $?", false, "")
 
 	e.Stop()
 	e.Cleanup()
@@ -138,8 +138,8 @@ func Test__DockerComposeExecutor__StopingRunningJob(t *testing.T) {
 	e, _, testLoggerBackend := startComposeExecutor()
 
 	go func() {
-		e.RunCommand("echo 'here'", false)
-		e.RunCommand("sleep 5", false)
+		e.RunCommand("echo 'here'", false, "")
+		e.RunCommand("sleep 5", false, "")
 	}()
 
 	time.Sleep(1 * time.Second)

--- a/pkg/executors/executor.go
+++ b/pkg/executors/executor.go
@@ -12,7 +12,7 @@ type Executor interface {
 	Start() int
 	ExportEnvVars([]api.EnvVar) int
 	InjectFiles([]api.File) int
-	RunCommand(string, bool) int
+	RunCommand(string, bool, string) int
 	Stop() int
 	Cleanup() int
 }

--- a/pkg/executors/shell_executor_test.go
+++ b/pkg/executors/shell_executor_test.go
@@ -27,21 +27,21 @@ func Test__ShellExecutor(t *testing.T) {
 	e.Prepare()
 	e.Start()
 
-	e.RunCommand("echo 'here'", false)
+	e.RunCommand("echo 'here'", false, "")
 
 	multilineCmd := `
 	  if [ -d /etc ]; then
 	    echo 'etc exists, multiline huzzahh!'
 	  fi
 	`
-	e.RunCommand(multilineCmd, false)
+	e.RunCommand(multilineCmd, false, "")
 
 	envVars := []api.EnvVar{
 		api.EnvVar{Name: "A", Value: "Zm9vCg=="},
 	}
 
 	e.ExportEnvVars(envVars)
-	e.RunCommand("echo $A", false)
+	e.RunCommand("echo $A", false, "")
 
 	files := []api.File{
 		api.File{
@@ -52,9 +52,9 @@ func Test__ShellExecutor(t *testing.T) {
 	}
 
 	e.InjectFiles(files)
-	e.RunCommand("cat /tmp/random-file.txt", false)
+	e.RunCommand("cat /tmp/random-file.txt", false, "")
 
-	e.RunCommand("echo $?", false)
+	e.RunCommand("echo $?", false, "")
 
 	e.Stop()
 	e.Cleanup()
@@ -107,8 +107,8 @@ func Test__ShellExecutor__StopingRunningJob(t *testing.T) {
 	e.Start()
 
 	go func() {
-		e.RunCommand("echo 'here'", false)
-		e.RunCommand("sleep 5", false)
+		e.RunCommand("echo 'here'", false, "")
+		e.RunCommand("sleep 5", false, "")
 	}()
 
 	time.Sleep(1 * time.Second)
@@ -144,7 +144,7 @@ func Test__ShellExecutor__LargeCommandOutput(t *testing.T) {
 	e.Start()
 
 	go func() {
-		e.RunCommand("for i in {1..100}; { printf 'hello'; }", false)
+		e.RunCommand("for i in {1..100}; { printf 'hello'; }", false, "")
 	}()
 
 	time.Sleep(5 * time.Second)

--- a/pkg/jobs/job.go
+++ b/pkg/jobs/job.go
@@ -156,7 +156,7 @@ func (job *Job) RunCommandsUntilFirstFailure(commands []api.Command) int {
 			return 1
 		}
 
-		lastExitCode = job.Executor.RunCommand(c.Directive, false)
+		lastExitCode = job.Executor.RunCommand(c.Directive, false, c.Alias)
 
 		if lastExitCode != 0 {
 			break

--- a/test/e2e/docker/command_aliases.rb
+++ b/test/e2e/docker/command_aliases.rb
@@ -1,0 +1,61 @@
+#!/bin/ruby
+# rubocop:disable all
+
+require_relative '../../e2e'
+
+start_job <<-JSON
+  {
+    "id": "#{$JOB_ID}",
+
+    "executor": "dockercompose",
+
+    "compose": {
+      "containers": [
+        {
+          "name": "main",
+          "image": "ruby:2.6"
+        }
+      ]
+    },
+
+    "env_vars": [],
+
+    "files": [],
+
+    "commands": [
+      { "directive": "echo Hello World", "alias": "Display Hello World" }
+    ],
+
+    "epilogue_always_commands": [],
+
+    "callbacks": {
+      "finished": "https://httpbin.org/status/200",
+      "teardown_finished": "https://httpbin.org/status/200"
+    }
+  }
+JSON
+
+wait_for_job_to_finish
+
+assert_job_log <<-LOG
+  {"event":"job_started",  "timestamp":"*"}
+  {"event":"cmd_started",  "timestamp":"*", "directive":"Pulling docker images..."}
+  *** LONG_OUTPUT ***
+  {"event":"cmd_finished", "timestamp":"*", "directive":"Pulling docker images...","event":"cmd_finished","exit_code":0,"finished_at":"*","started_at":"*","timestamp":"*"}
+
+  {"event":"cmd_started",  "timestamp":"*", "directive":"Starting the docker image..."}
+  {"event":"cmd_output",   "timestamp":"*", "output":"Starting a new bash session.\\n"}
+  {"event":"cmd_finished", "timestamp":"*", "directive":"Starting the docker image...","event":"cmd_finished","exit_code":0,"finished_at":"*","started_at":"*","timestamp":"*"}
+
+  {"event":"cmd_started",  "timestamp":"*", "directive":"Exporting environment variables"}
+  {"event":"cmd_finished", "timestamp":"*", "directive":"Exporting environment variables","exit_code":0,"finished_at":"*","started_at":"*"}
+  {"event":"cmd_started",  "timestamp":"*", "directive":"Injecting Files"}
+  {"event":"cmd_finished", "timestamp":"*", "directive":"Injecting Files","exit_code":0,"finished_at":"*","started_at":"*"}
+  {"event":"cmd_started",  "timestamp":"*", "directive":"Display Hello World"}
+  {"event":"cmd_output",   "timestamp":"*", "output":"Running: echo Hello World\\n"}
+  {"event":"cmd_output",   "timestamp":"*", "output":"Hello World\\n"}
+  {"event":"cmd_finished", "timestamp":"*", "directive":"Display Hello World","exit_code":0,"finished_at":"*","started_at":"*"}
+  {"event":"cmd_started",  "timestamp":"*", "directive":"export SEMAPHORE_JOB_RESULT=passed"}
+  {"event":"cmd_finished", "timestamp":"*", "directive":"export SEMAPHORE_JOB_RESULT=passed","exit_code":0,"finished_at":"*","started_at":"*"}
+  {"event":"job_finished", "timestamp":"*", "result":"passed"}
+LOG

--- a/test/e2e/shell/command_aliases.rb
+++ b/test/e2e/shell/command_aliases.rb
@@ -1,0 +1,42 @@
+#!/bin/ruby
+# rubocop:disable all
+
+require_relative '../../e2e'
+
+start_job <<-JSON
+  {
+    "id": "#{$JOB_ID}",
+
+    "env_vars": [],
+
+    "files": [],
+
+    "commands": [
+      { "directive": "echo Hello World", "alias": "Display Hello World" }
+    ],
+
+    "epilogue_always_commands": [],
+
+    "callbacks": {
+      "finished": "https://httpbin.org/status/200",
+      "teardown_finished": "https://httpbin.org/status/200"
+    }
+  }
+JSON
+
+wait_for_job_to_finish
+
+assert_job_log <<-LOG
+  {"event":"job_started",  "timestamp":"*"}
+  {"event":"cmd_started",  "timestamp":"*", "directive":"Exporting environment variables"}
+  {"event":"cmd_finished", "timestamp":"*", "directive":"Exporting environment variables","exit_code":0,"finished_at":"*","started_at":"*"}
+  {"event":"cmd_started",  "timestamp":"*", "directive":"Injecting Files"}
+  {"event":"cmd_finished", "timestamp":"*", "directive":"Injecting Files","exit_code":0,"finished_at":"*","started_at":"*"}
+  {"event":"cmd_started",  "timestamp":"*", "directive":"Display Hello World"}
+  {"event":"cmd_output",   "timestamp":"*", "output":"Running: echo Hello World\\n"}
+  {"event":"cmd_output",   "timestamp":"*", "output":"Hello World\\n"}
+  {"event":"cmd_finished", "timestamp":"*", "directive":"Display Hello World","exit_code":0,"finished_at":"*","started_at":"*"}
+  {"event":"cmd_started",  "timestamp":"*", "directive":"export SEMAPHORE_JOB_RESULT=passed"}
+  {"event":"cmd_finished", "timestamp":"*", "directive":"export SEMAPHORE_JOB_RESULT=passed","exit_code":0,"finished_at":"*","started_at":"*"}
+  {"event":"job_finished", "timestamp":"*", "result":"passed"}
+LOG


### PR DESCRIPTION
Command aliases come handy for commands that are executed during the environment setup phase.

For example, instead of 

```
git clone https://github.com/semaphoreci/toolbox.git ~/.toolbox && bash ~/.toolbox/install-toolbox && source ~/.toolbox/toolbox && echo 'source ~/.toolbox/toolbox' >> ~/.bash_profile
```
the job logs would display 

```
Setting up the Semaphore Toolbox
```