### PR TITLE
Add device /dev/kvm

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -125,6 +125,7 @@ blocks:
                 - unicode
                 - unknown_command
                 - broken_unicode
+                - check_dev_kvm
 
 promotions:
   - name: Release

--- a/pkg/executors/docker_compose_file.go
+++ b/pkg/executors/docker_compose_file.go
@@ -20,6 +20,7 @@ func (f *DockerComposeFile) Construct() string {
 	dockerCompose := ""
 	dockerCompose += "version: \"2.0\"\n"
 	dockerCompose += "\n"
+
 	dockerCompose += "services:\n"
 
 	main, rest := f.configuration.Containers[0], f.configuration.Containers[1:]
@@ -40,6 +41,8 @@ func (f *DockerComposeFile) Service(container api.Container) string {
 	result := ""
 	result += fmt.Sprintf("  %s:\n", container.Name)
 	result += fmt.Sprintf("    image: %s\n", container.Image)
+	result += "    devices:\n"
+	result += "      - \"/dev/kvm:/dev/kvm\"\n"
 
 	if container.Command != "" {
 		result += fmt.Sprintf("    command: %s\n", container.Command)

--- a/pkg/executors/docker_compose_file_test.go
+++ b/pkg/executors/docker_compose_file_test.go
@@ -40,11 +40,15 @@ func Test__DockerComposeFileConstruction(t *testing.T) {
 services:
   main:
     image: ruby:2.6
+    devices:
+      - "/dev/kvm:/dev/kvm"
     links:
       - db
 
   db:
     image: postgres:9.6
+    devices:
+      - "/dev/kvm:/dev/kvm"
     command: postgres start
     user: postgres
     entrypoint: /docker-entrypoint-initdb.d/init-user-db.sh

--- a/test/e2e/docker/check_dev_kvm.rb
+++ b/test/e2e/docker/check_dev_kvm.rb
@@ -1,0 +1,64 @@
+#!/bin/ruby
+# rubocop:disable all
+
+require_relative '../../e2e'
+
+start_job <<-JSON
+  {
+    "id": "#{$JOB_ID}",
+
+    "executor": "dockercompose",
+
+    "compose": {
+      "containers": [
+        {
+          "name": "main",
+          "image": "semaphoreci/ruby:2.6"
+        }
+      ]
+    },
+
+    "env_vars": [],
+
+    "files": [],
+
+    "commands": [
+      { "directive": "ls /dev | grep kvm" }
+    ],
+
+    "epilogue_always_commands": [],
+
+    "callbacks": {
+      "finished": "https://httpbin.org/status/200",
+      "teardown_finished": "https://httpbin.org/status/200"
+    }
+  }
+JSON
+
+wait_for_job_to_finish
+
+assert_job_log <<-LOG
+  {"event":"job_started",  "timestamp":"*"}
+  {"event":"cmd_started",  "timestamp":"*", "directive":"Pulling docker images..."}
+  *** LONG_OUTPUT ***
+  {"event":"cmd_finished", "timestamp":"*", "directive":"Pulling docker images...","event":"cmd_finished","exit_code":0,"finished_at":"*","started_at":"*","timestamp":"*"}
+
+  {"event":"cmd_started",  "timestamp":"*", "directive":"Starting the docker image..."}
+  {"event":"cmd_output",   "timestamp":"*", "output":"Starting a new bash session.\\n"}
+  {"event":"cmd_finished", "timestamp":"*", "directive":"Starting the docker image...","event":"cmd_finished","exit_code":0,"finished_at":"*","started_at":"*","timestamp":"*"}
+
+  {"event":"cmd_started",  "timestamp":"*", "directive":"Exporting environment variables"}
+  {"event":"cmd_finished", "timestamp":"*", "directive":"Exporting environment variables","exit_code":0,"finished_at":"*","started_at":"*"}
+  {"event":"cmd_started",  "timestamp":"*", "directive":"Injecting Files"}
+  {"event":"cmd_finished", "timestamp":"*", "directive":"Injecting Files","exit_code":0,"finished_at":"*","started_at":"*"}
+
+
+  {"event":"cmd_started",  "timestamp":"*", "directive":"ls /dev | grep kvm"}
+  {"event":"cmd_output",   "timestamp":"*", "output":"kvm\\n"}
+  {"event":"cmd_finished", "timestamp":"*", "directive":"ls /dev | grep kvm","event":"cmd_finished","exit_code":0,"finished_at":"*","started_at":"*","timestamp":"*"}
+ 
+  {"event":"cmd_started",  "timestamp":"*", "directive":"export SEMAPHORE_JOB_RESULT=passed"}
+  {"event":"cmd_finished", "timestamp":"*", "directive":"export SEMAPHORE_JOB_RESULT=passed","exit_code":0,"finished_at":"*","started_at":"*"}
+  {"event":"job_finished", "timestamp":"*", "result":"passed"}
+
+LOG


### PR DESCRIPTION
The reason for introducing this: android emulator won't start in compose style, because it needs `/dev/kvm` to be available in the container. See [issue](https://github.com/renderedtext/issues/issues/3231#issuecomment-593878135)