### PR TITLE
Handle 'exit 1', 'set -e', 'set -eo pipefail', and killing of the root shell

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -65,6 +65,9 @@ blocks:
                 - unicode
                 - unknown_command
                 - broken_unicode
+                - killing_root_bash
+                - set_e
+                - set_pipefail
 
   - name: "Docker Executor E2E"
     dependencies: []

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ docker.build: build
 
 docker.run: docker.build
 	-docker stop agent
-	docker run -v /tmp/agent-temp-directory/:/tmp/agent-temp-directory -v /var/run/docker.sock:/var/run/docker.sock -p $(AGENT_PORT_IN_TESTS):8000 -p $(AGENT_SSH_PORT_IN_TESTS):22 --name agent -tdi agent bash -c "service ssh restart && ./agent serve --auth-token-secret 'TzRVcspTmxhM9fUkdi1T/0kVXNETCi8UdZ8dLM8va4E'"
+	docker run --privileged --device /dev/ptmx -v /tmp/agent-temp-directory/:/tmp/agent-temp-directory -v /var/run/docker.sock:/var/run/docker.sock -p $(AGENT_PORT_IN_TESTS):8000 -p $(AGENT_SSH_PORT_IN_TESTS):22 --name agent -tdi agent bash -c "service ssh restart && nohup ./agent serve --auth-token-secret 'TzRVcspTmxhM9fUkdi1T/0kVXNETCi8UdZ8dLM8va4E' & sleep infinity"
 	sleep 2
 .PHONY: docker.run
 

--- a/pkg/shell/process.go
+++ b/pkg/shell/process.go
@@ -8,9 +8,11 @@ import (
 	"log"
 	"math/rand"
 	"os"
+	"os/signal"
 	"regexp"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 )
 
@@ -111,6 +113,10 @@ func (p *Process) flushInputBufferTill(index int) {
 }
 
 func (p *Process) Run() {
+
+	log.Println("Signals ===================================")
+	log.Println(signal.Ignored(syscall.SIGHUP))
+
 	instruction := p.constructShellInstruction()
 
 	p.StartedAt = int(time.Now().Unix())
@@ -194,7 +200,7 @@ func (p *Process) read() error {
 	log.Println("Reading started")
 	n, err := p.TTY.Read(buffer)
 	if err != nil {
-		log.Println("Error while reading from the tty")
+		log.Printf("Error while reading from the tty. Error: '%s'.", err.Error())
 		return err
 	}
 

--- a/pkg/shell/process.go
+++ b/pkg/shell/process.go
@@ -294,6 +294,12 @@ func (p *Process) scan() error {
 
 		err := p.read()
 		if err != nil {
+			// Reading failed. The most likely cause is that the bash process
+			// died. For example, running an `exit 1` command has killed it.
+
+			// Flushing all remaining data in the buffer and exiting.
+			p.flushOutputBuffer()
+
 			return err
 		}
 	}

--- a/pkg/shell/shell_test.go
+++ b/pkg/shell/shell_test.go
@@ -38,6 +38,37 @@ func Test__Shell__HandlingBashProcessKill(t *testing.T) {
 	assert.Equal(t, output.String(), "Hello\n")
 }
 
+func Test__Shell__HandlingBashProcessKillThatHasBackgroundJobs(t *testing.T) {
+	var output bytes.Buffer
+
+	//
+	// If a user starts a background job in the session, for example
+	// 'sleep infinity &' and then exists the shell, the Bash session will not
+	// be killed properly.
+	//
+	// It will enter a defunct state until its parent (the agent) reaps it.
+	//
+	// This test verifies that the reaping process is working properly and that
+	// it stops the read procedure.
+	//
+
+	shell := bashShell()
+
+	p1 := shell.NewProcess("sleep infinity &")
+	p1.OnStdout(func(line string) {
+		output.WriteString(line)
+	})
+	p1.Run()
+
+	p2 := shell.NewProcess("echo 'Hello' && exit 1")
+	p2.OnStdout(func(line string) {
+		output.WriteString(line)
+	})
+	p2.Run()
+
+	assert.Equal(t, output.String(), "Hello\n")
+}
+
 func tempStorageFolder() string {
 	dir, err := ioutil.TempDir("", "agent-test")
 	if err != nil {

--- a/pkg/shell/shell_test.go
+++ b/pkg/shell/shell_test.go
@@ -1,0 +1,71 @@
+package shell
+
+import (
+	"bytes"
+	"io/ioutil"
+	"log"
+	"os/exec"
+	"testing"
+	"time"
+
+	assert "github.com/stretchr/testify/assert"
+)
+
+func Test__Shell__SimpleHelloWorld(t *testing.T) {
+	var output bytes.Buffer
+
+	shell := bashShell()
+
+	p1 := shell.NewProcess("echo Hello")
+	p1.OnStdout(func(line string) {
+		output.WriteString(line)
+	})
+	p1.Run()
+
+	assert.Equal(t, output.String(), "Hello\n")
+}
+
+func Test__Shell__HandlingBashProcessKill(t *testing.T) {
+	var output bytes.Buffer
+
+	// c := make(chan os.Signal, 1)
+	// signal.Notify(c, syscall.SIGHUP)
+
+	// log.Println("Signal")
+	// log.Println(signal.Ignored(syscall.SIGHUP))
+	// signal.Reset(syscall.SIGHUP)
+	// log.Println(signal.Ignored(syscall.SIGHUP))
+
+	shell := bashShell()
+
+	p1 := shell.NewProcess("echo aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa && exit 1")
+	p1.OnStdout(func(line string) {
+		output.WriteString(line)
+	})
+	p1.Run()
+
+	log.Println("Finished")
+
+	assert.Equal(t, output.String(), "Hello\n")
+
+	time.Sleep(30 * time.Second)
+}
+
+func tempStorageFolder() string {
+	dir, err := ioutil.TempDir("", "agent-test")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	return dir
+}
+
+func bashShell() *Shell {
+	dir := tempStorageFolder()
+	cmd := exec.Command("bash", "--login")
+
+	shell, _ := NewShell(cmd, dir)
+	shell.Start()
+
+	return shell
+}

--- a/pkg/shell/shell_test.go
+++ b/pkg/shell/shell_test.go
@@ -6,7 +6,6 @@ import (
 	"log"
 	"os/exec"
 	"testing"
-	"time"
 
 	assert "github.com/stretchr/testify/assert"
 )
@@ -28,27 +27,15 @@ func Test__Shell__SimpleHelloWorld(t *testing.T) {
 func Test__Shell__HandlingBashProcessKill(t *testing.T) {
 	var output bytes.Buffer
 
-	// c := make(chan os.Signal, 1)
-	// signal.Notify(c, syscall.SIGHUP)
-
-	// log.Println("Signal")
-	// log.Println(signal.Ignored(syscall.SIGHUP))
-	// signal.Reset(syscall.SIGHUP)
-	// log.Println(signal.Ignored(syscall.SIGHUP))
-
 	shell := bashShell()
 
-	p1 := shell.NewProcess("echo aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa && exit 1")
+	p1 := shell.NewProcess("echo 'Hello' && exit 1")
 	p1.OnStdout(func(line string) {
 		output.WriteString(line)
 	})
 	p1.Run()
 
-	log.Println("Finished")
-
 	assert.Equal(t, output.String(), "Hello\n")
-
-	time.Sleep(30 * time.Second)
 }
 
 func tempStorageFolder() string {

--- a/test/e2e/shell/killing_root_bash.rb
+++ b/test/e2e/shell/killing_root_bash.rb
@@ -1,0 +1,36 @@
+#!/bin/ruby
+# rubocop:disable all
+
+require_relative '../../e2e'
+
+start_job <<-JSON
+  {
+    "id": "#{$JOB_ID}",
+
+    "env_vars": [],
+
+    "files": [],
+
+    "commands": [
+      { "directive": "exit 1" }
+    ],
+
+    "epilogue_always_commands": [],
+
+    "callbacks": {
+      "finished": "https://httpbin.org/status/200",
+      "teardown_finished": "https://httpbin.org/status/200"
+    }
+  }
+JSON
+
+wait_for_job_to_finish
+
+assert_job_log <<-LOG
+  {"event":"job_started",  "timestamp":"*"}
+  {"event":"cmd_started",  "timestamp":"*", "directive":"Exporting environment variables"}
+  {"event":"cmd_finished", "timestamp":"*", "directive":"Exporting environment variables","exit_code":0,"finished_at":"*","started_at":"*"}
+  {"event":"cmd_started",  "timestamp":"*", "directive":"Injecting Files"}
+  {"event":"cmd_finished", "timestamp":"*", "directive":"Injecting Files","exit_code":0,"finished_at":"*","started_at":"*"}
+  {"event":"cmd_started",  "timestamp":"*", "directive":"exit 1"}
+LOG

--- a/test/e2e/shell/set_e.rb
+++ b/test/e2e/shell/set_e.rb
@@ -7,7 +7,8 @@ require_relative '../../e2e'
 # Running the following set of commands caused the Agent to freeze up.
 #
 #   sleep infinity &
-#   exit 1
+#   set -e
+#   false
 #
 # These are regressions tests that verify that this is no longer a problem.
 #
@@ -22,7 +23,8 @@ start_job <<-JSON
 
     "commands": [
       { "directive": "sleep infinity &" },
-      { "directive": "exit 1" }
+      { "directive": "set -e" },
+      { "directive": "false" }
     ],
 
     "epilogue_always_commands": [],
@@ -44,8 +46,10 @@ assert_job_log <<-LOG
   {"event":"cmd_finished", "timestamp":"*", "directive":"Injecting Files","exit_code":0,"finished_at":"*","started_at":"*"}
   {"event":"cmd_started",  "timestamp":"*", "directive":"sleep infinity &"}
   {"event":"cmd_finished", "timestamp":"*", "directive":"sleep infinity &","exit_code":0,"finished_at":"*","started_at":"*"}
-  {"event":"cmd_started",  "timestamp":"*", "directive":"exit 1"}
-  {"event":"cmd_finished", "timestamp":"*", "directive":"exit 1","exit_code":1,"finished_at":"*","started_at":"*"}
+  {"event":"cmd_started",  "timestamp":"*", "directive":"set -e"}
+  {"event":"cmd_finished", "timestamp":"*", "directive":"set -e","exit_code":0,"finished_at":"*","started_at":"*"}
+  {"event":"cmd_started",  "timestamp":"*", "directive":"false"}
+  {"event":"cmd_finished", "timestamp":"*", "directive":"false","exit_code":1,"finished_at":"*","started_at":"*"}
   {"event":"cmd_started",  "timestamp":"*", "directive":"export SEMAPHORE_JOB_RESULT=failed"}
   {"event":"cmd_finished", "timestamp":"*", "directive":"export SEMAPHORE_JOB_RESULT=failed","exit_code":1,"started_at":"*","finished_at":"*"}
   {"event":"job_finished", "timestamp":"*", "result":"failed"}

--- a/test/e2e/shell/set_pipefail.rb
+++ b/test/e2e/shell/set_pipefail.rb
@@ -7,7 +7,8 @@ require_relative '../../e2e'
 # Running the following set of commands caused the Agent to freeze up.
 #
 #   sleep infinity &
-#   exit 1
+#   set -eo pipefail
+#   cat non_existant | sort
 #
 # These are regressions tests that verify that this is no longer a problem.
 #
@@ -22,7 +23,8 @@ start_job <<-JSON
 
     "commands": [
       { "directive": "sleep infinity &" },
-      { "directive": "exit 1" }
+      { "directive": "set -eo pipefail" },
+      { "directive": "cat non_existant | sort" }
     ],
 
     "epilogue_always_commands": [],
@@ -44,8 +46,11 @@ assert_job_log <<-LOG
   {"event":"cmd_finished", "timestamp":"*", "directive":"Injecting Files","exit_code":0,"finished_at":"*","started_at":"*"}
   {"event":"cmd_started",  "timestamp":"*", "directive":"sleep infinity &"}
   {"event":"cmd_finished", "timestamp":"*", "directive":"sleep infinity &","exit_code":0,"finished_at":"*","started_at":"*"}
-  {"event":"cmd_started",  "timestamp":"*", "directive":"exit 1"}
-  {"event":"cmd_finished", "timestamp":"*", "directive":"exit 1","exit_code":1,"finished_at":"*","started_at":"*"}
+  {"event":"cmd_started",  "timestamp":"*", "directive":"set -eo pipefail"}
+  {"event":"cmd_finished", "timestamp":"*", "directive":"set -eo pipefail","exit_code":0,"finished_at":"*","started_at":"*"}
+  {"event":"cmd_started",  "timestamp":"*", "directive":"cat non_existant | sort"}
+  {"event":"cmd_output",   "timestamp":"*", "output":"cat: non_existant: No such file or directory\\n"}
+  {"event":"cmd_finished", "timestamp":"*", "directive":"cat non_existant | sort","exit_code":1,"finished_at":"*","started_at":"*"}
   {"event":"cmd_started",  "timestamp":"*", "directive":"export SEMAPHORE_JOB_RESULT=failed"}
   {"event":"cmd_finished", "timestamp":"*", "directive":"export SEMAPHORE_JOB_RESULT=failed","exit_code":1,"started_at":"*","finished_at":"*"}
   {"event":"job_finished", "timestamp":"*", "result":"failed"}


### PR DESCRIPTION
The Agent gets stuck if we abruptly close the main Bash session.

This occurs when:

- A user command explicitly exits the shell with `exit 1`
- A user command sets the error mode in the shell with `set -e` and then runs a broken command
- A user command sets the pipefail mode in the shell with `set -o pipefail` and then runs a broken piped command

This PR solves this problem by monitoring the main bash session and reporting the problem.

---

### PR details

I had a hard time reproducing this bug. Running only `exit 1` was always handled properly. It took me a while to figure out how exactly to reproduce this. The trick was to have a background process that puts the Bash process in a defunct mode.

``` bash
sleep infinity &   # <- this (or any other background job) remains after exit and hangs 
exit 1
```

#### Why does this happen?

When we start a Bash session we are not communicating with it directly. We use a pseudo TTY.

<img width="623" alt="Screen Shot 2020-09-09 at 3 35 54 PM" src="https://user-images.githubusercontent.com/1779493/92605565-2d84cd80-f2b2-11ea-94d0-9f306c5cba62.png">

Now, when the Bash session exits, the `sleep infinity &` inherits the TTY. This puts the system in this state:

- Bash is dead.
- TTY is still active. We poll and try to read. 
 
#### How does this PR solve this issue?

We set up a listener that reacts to the Bash exit, and we propagate that information to the read procedure.

The read procedure can then selectively react to two events:

- Either the reading is finished
- Or, the exit handler is triggered

``` golang
var exitSignal chan string

func read() {
  done := make(chan bool, 1)

  go func() {
    tty.read(*buffer)
    done <- true
  }()

  select {
  case <- done:
     # reading succedded
  case <- exitSignal:
    # the shell was closed
  }  
}
```
