### PR TITLE
Do not panic if job cannot start

### DIFF
--- a/pkg/listener/job_processor.go
+++ b/pkg/listener/job_processor.go
@@ -107,7 +107,7 @@ func (p *JobProcessor) ProcessSyncResponse(response *selfhostedapi.SyncResponse)
 func (p *JobProcessor) RunJob(jobID string) {
 	p.State = selfhostedapi.AgentStateStartingJob
 
-	jobRequest, err := p.getJobWithRetries(p.CurrentJobID)
+	jobRequest, err := p.getJobWithRetries(jobID)
 	if err != nil {
 		log.Errorf("Could not get job details for %s: %v", jobID, err)
 		p.WaitForJobs()

--- a/pkg/listener/selfhostedapi/sync.go
+++ b/pkg/listener/selfhostedapi/sync.go
@@ -14,9 +14,9 @@ type AgentState string
 type AgentAction string
 
 const AgentStateWaitingForJobs = "waiting-for-jobs"
+const AgentStateStartingJob = "starting-job"
 const AgentStateRunningJob = "running-job"
 const AgentStateStoppingJob = "stopping-job"
-const AgentStateFinishedJob = "finished-job"
 
 const AgentActionWaitForJobs = "wait-for-jobs"
 const AgentActionRunJob = "run-job"

--- a/test/hub_reference/app.rb
+++ b/test/hub_reference/app.rb
@@ -53,6 +53,8 @@ post "/api/v1/self_hosted_agents/sync" do
               else
                 {"action" => "continue"}
               end
+            when "starting-job"
+              {"action" => "continue"}
             when "running-job"
               job_id = @json_request["job_id"]
               if $job_states[job_id] == "stopping"
@@ -61,8 +63,6 @@ post "/api/v1/self_hosted_agents/sync" do
                 {"action" => "continue"}
               end
             when "stopping-job"
-              {"action" => "continue"}
-            when "finished-job"
               {"action" => "continue"}
             else
               raise "unknown state"


### PR DESCRIPTION
- Related to https://github.com/renderedtext/alles/pull/187 
- No more panic() on errors getting job payload or creating jobs
- Added `starting-job` status to indicate the period where the agent is still grabbing the job details and constructing the job, and not yet running it
- Removed `finished-job` status, since it wasn't being used for anything