### PR TITLE
Improve stopping job

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -59,23 +59,23 @@ blocks:
                 - listen
             - env_var: TEST
               values:
-                - command_aliases
-                - env_vars
-                - failed_job
+                # - command_aliases
+                # - env_vars
+                # - failed_job
                 - job_stopping
                 - job_stopping_on_epilogue
-                - file_injection
-                - file_injection_broken_file_mode
-                - stty_restoration
-                - epilogue_on_pass
-                - epilogue_on_fail
-                - ssh_jump_points
-                - unicode
-                - unknown_command
-                - broken_unicode
-                - killing_root_bash
-                - set_e
-                - set_pipefail
+                # - file_injection
+                # - file_injection_broken_file_mode
+                # - stty_restoration
+                # - epilogue_on_pass
+                # - epilogue_on_fail
+                # - ssh_jump_points
+                # - unicode
+                # - unknown_command
+                # - broken_unicode
+                # - killing_root_bash
+                # - set_e
+                # - set_pipefail
 
   - name: "Docker Executor E2E"
     dependencies: []
@@ -113,37 +113,37 @@ blocks:
                 - listen
             - env_var: TEST
               values:
-                - hello_world
-                - command_aliases
-                - env_vars
-                - failed_job
+                # - hello_world
+                # - command_aliases
+                # - env_vars
+                # - failed_job
                 - job_stopping
                 - job_stopping_on_epilogue
-                - file_injection
-                - file_injection_broken_file_mode
-                - stty_restoration
-                - epilogue_on_pass
-                - epilogue_on_fail
-                - docker_in_docker
-                - container_env_vars
-                - container_options
-                - dockerhub_private_image
-                - docker_registry_private_image
-                - docker_private_image_ecr
-                - docker_private_image_gcr
-                - dockerhub_private_image_bad_creds
-                - docker_registry_private_image_bad_creds
-                - docker_private_image_ecr_bad_creds
-                - docker_private_image_gcr_bad_creds
-                - ssh_jump_points
-                - no_bash
-                - container_custom_name
-                - unicode
-                - unknown_command
-                - broken_unicode
-                - check_dev_kvm
-                - host_setup_commands
-                - multiple_containers
+                # - file_injection
+                # - file_injection_broken_file_mode
+                # - stty_restoration
+                # - epilogue_on_pass
+                # - epilogue_on_fail
+                # - docker_in_docker
+                # - container_env_vars
+                # - container_options
+                # - dockerhub_private_image
+                # - docker_registry_private_image
+                # - docker_private_image_ecr
+                # - docker_private_image_gcr
+                # - dockerhub_private_image_bad_creds
+                # - docker_registry_private_image_bad_creds
+                # - docker_private_image_ecr_bad_creds
+                # - docker_private_image_gcr_bad_creds
+                # - ssh_jump_points
+                # - no_bash
+                # - container_custom_name
+                # - unicode
+                # - unknown_command
+                # - broken_unicode
+                # - check_dev_kvm
+                # - host_setup_commands
+                # - multiple_containers
 
   - name: "Self hosted E2E"
     dependencies: []

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -59,23 +59,23 @@ blocks:
                 - listen
             - env_var: TEST
               values:
-                # - command_aliases
-                # - env_vars
-                # - failed_job
+                - command_aliases
+                - env_vars
+                - failed_job
                 - job_stopping
                 - job_stopping_on_epilogue
-                # - file_injection
-                # - file_injection_broken_file_mode
-                # - stty_restoration
-                # - epilogue_on_pass
-                # - epilogue_on_fail
-                # - ssh_jump_points
-                # - unicode
-                # - unknown_command
-                # - broken_unicode
-                # - killing_root_bash
-                # - set_e
-                # - set_pipefail
+                - file_injection
+                - file_injection_broken_file_mode
+                - stty_restoration
+                - epilogue_on_pass
+                - epilogue_on_fail
+                - ssh_jump_points
+                - unicode
+                - unknown_command
+                - broken_unicode
+                - killing_root_bash
+                - set_e
+                - set_pipefail
 
   - name: "Docker Executor E2E"
     dependencies: []
@@ -113,64 +113,64 @@ blocks:
                 - listen
             - env_var: TEST
               values:
-                # - hello_world
-                # - command_aliases
-                # - env_vars
-                # - failed_job
+                - hello_world
+                - command_aliases
+                - env_vars
+                - failed_job
                 - job_stopping
                 - job_stopping_on_epilogue
-                # - file_injection
-                # - file_injection_broken_file_mode
-                # - stty_restoration
-                # - epilogue_on_pass
-                # - epilogue_on_fail
-                # - docker_in_docker
-                # - container_env_vars
-                # - container_options
-                # - dockerhub_private_image
-                # - docker_registry_private_image
-                # - docker_private_image_ecr
-                # - docker_private_image_gcr
-                # - dockerhub_private_image_bad_creds
-                # - docker_registry_private_image_bad_creds
-                # - docker_private_image_ecr_bad_creds
-                # - docker_private_image_gcr_bad_creds
-                # - ssh_jump_points
-                # - no_bash
-                # - container_custom_name
-                # - unicode
-                # - unknown_command
-                # - broken_unicode
-                # - check_dev_kvm
-                # - host_setup_commands
-                # - multiple_containers
+                - file_injection
+                - file_injection_broken_file_mode
+                - stty_restoration
+                - epilogue_on_pass
+                - epilogue_on_fail
+                - docker_in_docker
+                - container_env_vars
+                - container_options
+                - dockerhub_private_image
+                - docker_registry_private_image
+                - docker_private_image_ecr
+                - docker_private_image_gcr
+                - dockerhub_private_image_bad_creds
+                - docker_registry_private_image_bad_creds
+                - docker_private_image_ecr_bad_creds
+                - docker_private_image_gcr_bad_creds
+                - ssh_jump_points
+                - no_bash
+                - container_custom_name
+                - unicode
+                - unknown_command
+                - broken_unicode
+                - check_dev_kvm
+                - host_setup_commands
+                - multiple_containers
 
-  # - name: "Self hosted E2E"
-  #   dependencies: []
-  #   task:
-  #     env_vars:
-  #       - name: GO111MODULE
-  #         value: "on"
-  #       - name: TEST_MODE
-  #         value: "listen"
+  - name: "Self hosted E2E"
+    dependencies: []
+    task:
+      env_vars:
+        - name: GO111MODULE
+          value: "on"
+        - name: TEST_MODE
+          value: "listen"
 
-  #     prologue:
-  #       commands:
-  #         - sem-version go 1.13
-  #         - checkout
-  #         - go version
-  #         - go get
-  #         - go build
-  #     jobs:
-  #       - name: Self hosted
-  #         commands:
-  #           - "make e2e TEST=self-hosted/$TEST"
-  #         matrix:
-  #           - env_var: TEST
-  #             values:
-  #               - broken_finished_callback
-  #               - broken_teardown_callback
-  #               - broken_get_job
+      prologue:
+        commands:
+          - sem-version go 1.13
+          - checkout
+          - go version
+          - go get
+          - go build
+      jobs:
+        - name: Self hosted
+          commands:
+            - "make e2e TEST=self-hosted/$TEST"
+          matrix:
+            - env_var: TEST
+              values:
+                - broken_finished_callback
+                - broken_teardown_callback
+                - broken_get_job
 
 promotions:
   - name: Release

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -63,6 +63,7 @@ blocks:
                 - env_vars
                 - failed_job
                 - job_stopping
+                - job_stopping_on_epilogue
                 - file_injection
                 - file_injection_broken_file_mode
                 - stty_restoration
@@ -117,6 +118,7 @@ blocks:
                 - env_vars
                 - failed_job
                 - job_stopping
+                - job_stopping_on_epilogue
                 - file_injection
                 - file_injection_broken_file_mode
                 - stty_restoration

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -145,32 +145,32 @@ blocks:
                 # - host_setup_commands
                 # - multiple_containers
 
-  - name: "Self hosted E2E"
-    dependencies: []
-    task:
-      env_vars:
-        - name: GO111MODULE
-          value: "on"
-        - name: TEST_MODE
-          value: "listen"
+  # - name: "Self hosted E2E"
+  #   dependencies: []
+  #   task:
+  #     env_vars:
+  #       - name: GO111MODULE
+  #         value: "on"
+  #       - name: TEST_MODE
+  #         value: "listen"
 
-      prologue:
-        commands:
-          - sem-version go 1.13
-          - checkout
-          - go version
-          - go get
-          - go build
-      jobs:
-        - name: Self hosted
-          commands:
-            - "make e2e TEST=self-hosted/$TEST"
-          matrix:
-            - env_var: TEST
-              values:
-                - broken_finished_callback
-                - broken_teardown_callback
-                - broken_get_job
+  #     prologue:
+  #       commands:
+  #         - sem-version go 1.13
+  #         - checkout
+  #         - go version
+  #         - go get
+  #         - go build
+  #     jobs:
+  #       - name: Self hosted
+  #         commands:
+  #           - "make e2e TEST=self-hosted/$TEST"
+  #         matrix:
+  #           - env_var: TEST
+  #             values:
+  #               - broken_finished_callback
+  #               - broken_teardown_callback
+  #               - broken_get_job
 
 promotions:
   - name: Release

--- a/pkg/jobs/job.go
+++ b/pkg/jobs/job.go
@@ -15,6 +15,7 @@ import (
 
 const JOB_PASSED = "passed"
 const JOB_FAILED = "failed"
+const JOB_STOPPED = "stopped"
 
 type Job struct {
 	Client  *http.Client
@@ -26,17 +27,6 @@ type Job struct {
 	JobLogArchived bool
 	Stopped        bool
 	Finished       bool
-
-	//
-	// The Teardown phase can be entered either after:
-	//  - a regular job execution ends
-	//  - from the Job.Stop procedure
-	//
-	// With this lock, we are making sure that only one Teardown is
-	// executed. This solves the race condition where both the job finishes
-	// and the job stops at the same time.
-	//
-	TeardownLock Lock
 }
 
 func NewJob(request *api.JobRequest, client *http.Client) (*Job, error) {
@@ -92,30 +82,8 @@ func (job *Job) RunWithCallbacks(onSuccessfulTeardown func(), onFailedTeardown f
 
 	if executorRunning {
 		result = job.RunRegularCommands()
-
-		if result == JOB_PASSED {
-			log.Info("Regular commands finished successfully")
-		} else {
-			log.Info("Regular commands finished with failure")
-		}
-
-		log.Debug("Exporting job result")
-
-		job.RunCommandsUntilFirstFailure([]api.Command{
-			{
-				Directive: fmt.Sprintf("export SEMAPHORE_JOB_RESULT=%s", result),
-			},
-		})
-
-		log.Info("Starting epilogue always commands")
-		job.RunCommandsUntilFirstFailure(job.Request.EpilogueAlwaysCommands)
-
-		if result == JOB_PASSED {
-			log.Info("Starting epilogue on pass commands")
-			job.RunCommandsUntilFirstFailure(job.Request.EpilogueOnPassCommands)
-		} else {
-			log.Info("Starting epilogue on fail commands")
-			job.RunCommandsUntilFirstFailure(job.Request.EpilogueOnFailCommands)
+		if result != JOB_STOPPED {
+			job.handleEpilogues(result)
 		}
 	}
 
@@ -127,7 +95,11 @@ func (job *Job) RunWithCallbacks(onSuccessfulTeardown func(), onFailedTeardown f
 	}
 
 	job.Finished = true
-	job.Executor.Stop()
+
+	// the executor is already stopped when the job is stopped, so there's no need to stop it again
+	if !job.Stopped {
+		job.Executor.Stop()
+	}
 }
 
 func (job *Job) PrepareEnvironment() int {
@@ -163,10 +135,35 @@ func (job *Job) RunRegularCommands() string {
 
 	exitCode = job.RunCommandsUntilFirstFailure(job.Request.Commands)
 
-	if exitCode == 0 {
+	if job.Stopped {
+		log.Info("Regular commands were stopped")
+		return JOB_STOPPED
+	} else if exitCode == 0 {
+		log.Info("Regular commands finished successfully")
 		return JOB_PASSED
 	} else {
+		log.Info("Regular commands finished with failure")
 		return JOB_FAILED
+	}
+}
+
+func (job *Job) handleEpilogues(result string) {
+	log.Debug("Exporting job result")
+	job.RunCommandsUntilFirstFailure([]api.Command{
+		{
+			Directive: fmt.Sprintf("export SEMAPHORE_JOB_RESULT=%s", result),
+		},
+	})
+
+	log.Info("Starting epilogue always commands")
+	job.RunCommandsUntilFirstFailure(job.Request.EpilogueAlwaysCommands)
+
+	if result == JOB_PASSED {
+		log.Info("Starting epilogue on pass commands")
+		job.RunCommandsUntilFirstFailure(job.Request.EpilogueOnPassCommands)
+	} else {
+		log.Info("Starting epilogue on fail commands")
+		job.RunCommandsUntilFirstFailure(job.Request.EpilogueOnFailCommands)
 	}
 }
 
@@ -190,11 +187,6 @@ func (job *Job) RunCommandsUntilFirstFailure(commands []api.Command) int {
 }
 
 func (job *Job) Teardown(result string) error {
-	if !job.TeardownLock.TryLock() {
-		log.Warning("Duplicate attempts to enter the Teardown phase")
-		return nil
-	}
-
 	err := job.SendFinishedCallback(result)
 	if err != nil {
 		log.Errorf("Could not send finished callback: %v", err)
@@ -242,8 +234,6 @@ func (j *Job) Stop() {
 	PreventPanicPropagation(func() {
 		j.Executor.Stop()
 	})
-
-	j.Teardown("stopped")
 }
 
 func (job *Job) SendFinishedCallback(result string) error {

--- a/test/e2e/docker/job_stopping_on_epilogue.rb
+++ b/test/e2e/docker/job_stopping_on_epilogue.rb
@@ -1,0 +1,52 @@
+#!/bin/ruby
+# rubocop:disable all
+
+require_relative '../../e2e'
+
+start_job <<-JSON
+  {
+    "id": "#{$JOB_ID}",
+
+    "env_vars": [],
+
+    "files": [],
+
+    "commands": [
+      { "directive": "echo 'here'" }
+    ],
+
+    "epilogue_always_commands": [
+      { "directive": "sleep infinity" }
+    ],
+
+    "callbacks": {
+      "finished": "#{finished_callback_url}",
+      "teardown_finished": "#{teardown_callback_url}"
+    },
+    "logger": #{$LOGGER}
+  }
+JSON
+
+wait_for_command_to_start("sleep infinity")
+
+sleep 1
+
+stop_job
+
+wait_for_job_to_finish
+
+assert_job_log <<-LOG
+  {"event":"job_started",  "timestamp":"*"}
+  {"event":"cmd_started",  "timestamp":"*", "directive":"Exporting environment variables"}
+  {"event":"cmd_finished", "timestamp":"*", "directive":"Exporting environment variables","exit_code":0,"finished_at":"*","started_at":"*"}
+  {"event":"cmd_started",  "timestamp":"*", "directive":"Injecting Files"}
+  {"event":"cmd_finished", "timestamp":"*", "directive":"Injecting Files","exit_code":0,"finished_at":"*","started_at":"*"}
+  {"event":"cmd_started",  "timestamp":"*", "directive":"echo 'here'"}
+  {"event":"cmd_output",   "timestamp":"*", "output":"here\\n"}
+  {"event":"cmd_finished", "timestamp":"*", "directive":"echo 'here'","exit_code":0,"finished_at":"*","started_at":"*"}
+  {"event":"cmd_started",  "timestamp":"*", "directive":"export SEMAPHORE_JOB_RESULT=passed"}
+  {"event":"cmd_finished", "timestamp":"*", "directive":"export SEMAPHORE_JOB_RESULT=passed","exit_code":0,"started_at":"*","finished_at":"*"}
+  {"event":"cmd_started",  "timestamp":"*", "directive":"sleep infinity"}
+  {"event":"cmd_finished", "timestamp":"*", "directive":"sleep infinity","exit_code":1,"finished_at":"*","started_at":"*"}
+  {"event":"job_finished", "timestamp":"*", "result":"stopped"}
+LOG

--- a/test/e2e/shell/job_stopping_on_epilogue.rb
+++ b/test/e2e/shell/job_stopping_on_epilogue.rb
@@ -1,0 +1,52 @@
+#!/bin/ruby
+# rubocop:disable all
+
+require_relative '../../e2e'
+
+start_job <<-JSON
+  {
+    "id": "#{$JOB_ID}",
+
+    "env_vars": [],
+
+    "files": [],
+
+    "commands": [
+      { "directive": "echo 'here'" }
+    ],
+
+    "epilogue_always_commands": [
+      { "directive": "sleep infinity" }
+    ],
+
+    "callbacks": {
+      "finished": "#{finished_callback_url}",
+      "teardown_finished": "#{teardown_callback_url}"
+    },
+    "logger": #{$LOGGER}
+  }
+JSON
+
+wait_for_command_to_start("sleep infinity")
+
+sleep 1
+
+stop_job
+
+wait_for_job_to_finish
+
+assert_job_log <<-LOG
+  {"event":"job_started",  "timestamp":"*"}
+  {"event":"cmd_started",  "timestamp":"*", "directive":"Exporting environment variables"}
+  {"event":"cmd_finished", "timestamp":"*", "directive":"Exporting environment variables","exit_code":0,"finished_at":"*","started_at":"*"}
+  {"event":"cmd_started",  "timestamp":"*", "directive":"Injecting Files"}
+  {"event":"cmd_finished", "timestamp":"*", "directive":"Injecting Files","exit_code":0,"finished_at":"*","started_at":"*"}
+  {"event":"cmd_started",  "timestamp":"*", "directive":"echo 'here'"}
+  {"event":"cmd_output",   "timestamp":"*", "output":"here\\n"}
+  {"event":"cmd_finished", "timestamp":"*", "directive":"echo 'here'","exit_code":0,"finished_at":"*","started_at":"*"}
+  {"event":"cmd_started",  "timestamp":"*", "directive":"export SEMAPHORE_JOB_RESULT=passed"}
+  {"event":"cmd_finished", "timestamp":"*", "directive":"export SEMAPHORE_JOB_RESULT=passed","exit_code":0,"started_at":"*","finished_at":"*"}
+  {"event":"cmd_started",  "timestamp":"*", "directive":"sleep infinity"}
+  {"event":"cmd_finished", "timestamp":"*", "directive":"sleep infinity","exit_code":1,"finished_at":"*","started_at":"*"}
+  {"event":"job_finished", "timestamp":"*", "result":"stopped"}
+LOG


### PR DESCRIPTION
When stopping a job, `job.Teardown()` is called from two places:
1. `job.Run()` (after the command that was interrupted fails)
2. `job.Stop()`

If `#1` executes first, job finishes with result failed (it should be stopped). https://semaphore.semaphoreci.com/jobs/2463f0a2-e81b-42db-be66-deb66e69feab is an example of that:
```
Comparing log lines Actual=27 Expected=13
  actual:   {"event":"job_finished","timestamp":1627676155,"result":"failed"}
  expected: {"event":"job_finished", "timestamp":"*", "result":"stopped"}
(fail) Values for 'result' are not equal.
Makefile:30: recipe for target 'e2e' failed
make: *** [e2e] Error 1
```

If `#2` executes first and the logs are flushed before the interrupted command fails, we miss the `cmd_finished` log event. https://semaphore.semaphoreci.com/jobs/859e2947-4f66-40c7-9b0d-2bdca6e4e2f8 is an example of that:

```
Comparing log lines Actual=26 Expected=12
  actual:   {"event":"job_finished","timestamp":1627675494,"result":"stopped"}
  expected: {"event":"cmd_finished", "timestamp":"*", "directive":"sleep infinity","exit_code":1,"finished_at":"*","started_at":"*"}
(fail) JSON keys are different.
Makefile:30: recipe for target 'e2e' failed
make: *** [e2e] Error 1
```

The solution in this PR is basically removing the race condition by removing the `job.Teardown()` from `job.Stop()` and letting the teardown for a stopped job run when the interrupted command fails.

- I ran 10 builds on a [branch which only executed the `job_stopping` tests](https://semaphore.semaphoreci.com/branches/2cc67bc8-0be5-4fc2-aa50-832b7996d8b9) without these fixes, and got 7/10 builds green
- I ran 10 builds on this branch with the fixes and got 10/10 builds green
