### PR TITLE
Add `--env-vars` option to expose environment variables to jobs from the agent

### DIFF
--- a/main.go
+++ b/main.go
@@ -77,7 +77,7 @@ func RunListener(httpClient *http.Client, logfile io.Writer) {
 	noHttps := pflag.Bool("no-https", false, "Use http for communication")
 	shutdownHookPath := pflag.String("shutdown-hook-path", "", "Shutdown hook path")
 	disconnectAfterJob := pflag.Bool("disconnect-after-job", false, "Disconnect after job")
-	envVars := pflag.StringSlice("env-vars", []string{}, "Environment variables to expose to jobs")
+	envVars := pflag.StringSlice("env-vars", []string{}, "Export environment variables in jobs")
 
 	pflag.Parse()
 
@@ -112,17 +112,20 @@ func RunListener(httpClient *http.Client, logfile io.Writer) {
 }
 
 func ParseEnvVars(envVars []string) ([]config.HostEnvVar, error) {
-	converted := []config.HostEnvVar{}
+	vars := []config.HostEnvVar{}
 	for _, envVar := range envVars {
 		nameAndValue := strings.Split(envVar, "=")
 		if len(nameAndValue) != 2 {
 			return nil, fmt.Errorf("%s is not a valid environment variable", envVar)
 		}
 
-		converted = append(converted, config.HostEnvVar{Name: nameAndValue[0], Value: nameAndValue[1]})
+		vars = append(vars, config.HostEnvVar{
+			Name:  nameAndValue[0],
+			Value: nameAndValue[1],
+		})
 	}
 
-	return converted, nil
+	return vars, nil
 }
 
 func RunServer(httpClient *http.Client, logfile io.Writer) {

--- a/main.go
+++ b/main.go
@@ -6,10 +6,12 @@ import (
 	"math/rand"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	watchman "github.com/renderedtext/go-watchman"
 	api "github.com/semaphoreci/agent/pkg/api"
+	"github.com/semaphoreci/agent/pkg/config"
 	"github.com/semaphoreci/agent/pkg/eventlogger"
 	jobs "github.com/semaphoreci/agent/pkg/jobs"
 	listener "github.com/semaphoreci/agent/pkg/listener"
@@ -75,12 +77,18 @@ func RunListener(httpClient *http.Client, logfile io.Writer) {
 	noHttps := pflag.Bool("no-https", false, "Use http for communication")
 	shutdownHookPath := pflag.String("shutdown-hook-path", "", "Shutdown hook path")
 	disconnectAfterJob := pflag.Bool("disconnect-after-job", false, "Disconnect after job")
+	envVars := pflag.StringSlice("env-vars", []string{}, "Environment variables to expose to jobs")
 
 	pflag.Parse()
 
 	scheme := "https"
 	if *noHttps {
 		scheme = "http"
+	}
+
+	hostEnvVars, err := ParseEnvVars(*envVars)
+	if err != nil {
+		log.Fatalf("Error parsing environment variables: %v", err)
 	}
 
 	config := listener.Config{
@@ -90,6 +98,7 @@ func RunListener(httpClient *http.Client, logfile io.Writer) {
 		Scheme:             scheme,
 		ShutdownHookPath:   *shutdownHookPath,
 		DisconnectAfterJob: *disconnectAfterJob,
+		EnvVars:            hostEnvVars,
 	}
 
 	go func() {
@@ -100,6 +109,20 @@ func RunListener(httpClient *http.Client, logfile io.Writer) {
 	}()
 
 	select {}
+}
+
+func ParseEnvVars(envVars []string) ([]config.HostEnvVar, error) {
+	converted := []config.HostEnvVar{}
+	for _, envVar := range envVars {
+		nameAndValue := strings.Split(envVar, "=")
+		if len(nameAndValue) != 2 {
+			return nil, fmt.Errorf("%s is not a valid environment variable", envVar)
+		}
+
+		converted = append(converted, config.HostEnvVar{Name: nameAndValue[0], Value: nameAndValue[1]})
+	}
+
+	return converted, nil
 }
 
 func RunServer(httpClient *http.Client, logfile io.Writer) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,0 +1,6 @@
+package config
+
+type HostEnvVar struct {
+	Name  string
+	Value string
+}

--- a/pkg/executors/docker_compose_executor_test.go
+++ b/pkg/executors/docker_compose_executor_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	api "github.com/semaphoreci/agent/pkg/api"
+	"github.com/semaphoreci/agent/pkg/config"
 	eventlogger "github.com/semaphoreci/agent/pkg/eventlogger"
 	assert "github.com/stretchr/testify/assert"
 )
@@ -77,7 +78,7 @@ func Test__DockerComposeExecutor(t *testing.T) {
 		api.EnvVar{Name: "A", Value: "Zm9vCg=="},
 	}
 
-	e.ExportEnvVars(envVars)
+	e.ExportEnvVars(envVars, []config.HostEnvVar{})
 	e.RunCommand("echo $A", false, "")
 
 	files := []api.File{

--- a/pkg/executors/executor.go
+++ b/pkg/executors/executor.go
@@ -4,13 +4,14 @@ import (
 	"fmt"
 
 	api "github.com/semaphoreci/agent/pkg/api"
+	"github.com/semaphoreci/agent/pkg/config"
 	eventlogger "github.com/semaphoreci/agent/pkg/eventlogger"
 )
 
 type Executor interface {
 	Prepare() int
 	Start() int
-	ExportEnvVars([]api.EnvVar) int
+	ExportEnvVars([]api.EnvVar, []config.HostEnvVar) int
 	InjectFiles([]api.File) int
 	RunCommand(string, bool, string) int
 	Stop() int
@@ -27,6 +28,6 @@ func CreateExecutor(request *api.JobRequest, logger *eventlogger.Logger, exposeK
 	case ExecutorTypeDockerCompose:
 		return NewDockerComposeExecutor(request, logger, exposeKvmDevice), nil
 	default:
-		return nil, fmt.Errorf("Uknown executor type")
+		return nil, fmt.Errorf("unknown executor type")
 	}
 }

--- a/pkg/executors/shell_executor_test.go
+++ b/pkg/executors/shell_executor_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	api "github.com/semaphoreci/agent/pkg/api"
+	"github.com/semaphoreci/agent/pkg/config"
 	eventlogger "github.com/semaphoreci/agent/pkg/eventlogger"
 	testsupport "github.com/semaphoreci/agent/test/support"
 	assert "github.com/stretchr/testify/assert"
@@ -40,7 +41,7 @@ func Test__ShellExecutor(t *testing.T) {
 		api.EnvVar{Name: "A", Value: "Zm9vCg=="},
 	}
 
-	e.ExportEnvVars(envVars)
+	e.ExportEnvVars(envVars, []config.HostEnvVar{})
 	e.RunCommand("echo $A", false, "")
 
 	files := []api.File{

--- a/pkg/listener/listener.go
+++ b/pkg/listener/listener.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/semaphoreci/agent/pkg/config"
 	selfhostedapi "github.com/semaphoreci/agent/pkg/listener/selfhostedapi"
 	"github.com/semaphoreci/agent/pkg/retry"
 	log "github.com/sirupsen/logrus"
@@ -26,6 +27,7 @@ type Config struct {
 	Scheme             string
 	ShutdownHookPath   string
 	DisconnectAfterJob bool
+	EnvVars            []config.HostEnvVar
 }
 
 func Start(httpClient *http.Client, config Config, logger io.Writer) (*Listener, error) {
@@ -44,7 +46,7 @@ func Start(httpClient *http.Client, config Config, logger io.Writer) (*Listener,
 	}
 
 	log.Info("Starting to poll for jobs")
-	jobProcessor, err := StartJobProcessor(httpClient, listener.Client, config.ShutdownHookPath, config.DisconnectAfterJob)
+	jobProcessor, err := StartJobProcessor(httpClient, listener.Client, listener.Config)
 	if err != nil {
 		return listener, err
 	}


### PR DESCRIPTION
The `--env-vars` option accepts a comma-separated list of `NAME=VALUE` environment variables. For example:

```sh
/opt/semaphore/agent start \
  --env-vars MY_HOST_VAR_1=AAAA,MY_HOST_VAR_2=BBBB \
  --endpoint ... \
  --token ...
```

- Job using docker compose executor example: https://semaphore.semaphoreci.com/jobs/7fb8b6f9-eee3-4b77-b1e0-fb69297cf915
- Job using shell executor example: https://semaphore.semaphoreci.com/jobs/57ed04a1-8917-4288-818d-66eaf0b17bb4

If the option doesn't receive the proper format, the agent won't start up. For example:

```
/opt/semaphore/agent start \
  --env-vars MY_HOST_VAR_1=AAAA,MY_HOST_VAR_2 \
  --endpoint ... \
  --token ...
```

gives the following error:

```
Aug  5 17:24:14.289 : Error parsing environment variables: MY_HOST_VAR_2 is not a valid environment variable
```