### PR TITLE
Add `--files` option to inject files from host into main docker container

### DIFF
--- a/main.go
+++ b/main.go
@@ -79,6 +79,7 @@ func RunListener(httpClient *http.Client, logfile io.Writer) {
 	disconnectAfterJob := pflag.Bool("disconnect-after-job", false, "Disconnect after job")
 	envVars := pflag.StringSlice("env-vars", []string{}, "Export environment variables in jobs")
 	files := pflag.StringSlice("files", []string{}, "Inject files into container, when using docker compose executor")
+	failOnMissingFiles := pflag.Bool("fail-on-missing-files", false, "Fail job if files specified using --files are missing")
 
 	pflag.Parse()
 
@@ -106,6 +107,7 @@ func RunListener(httpClient *http.Client, logfile io.Writer) {
 		DisconnectAfterJob: *disconnectAfterJob,
 		EnvVars:            hostEnvVars,
 		FileInjections:     fileInjections,
+		FailOnMissingFiles: *failOnMissingFiles,
 	}
 
 	go func() {

--- a/main.go
+++ b/main.go
@@ -138,20 +138,20 @@ func ParseEnvVars(envVars []string) ([]config.HostEnvVar, error) {
 }
 
 func ParseFiles(files []string) ([]config.FileInjection, error) {
-	FileInjections := []config.FileInjection{}
+	fileInjections := []config.FileInjection{}
 	for _, file := range files {
 		hostPathAndDestination := strings.Split(file, ":")
 		if len(hostPathAndDestination) != 2 {
 			return nil, fmt.Errorf("%s is not a valid file injection", file)
 		}
 
-		FileInjections = append(FileInjections, config.FileInjection{
+		fileInjections = append(fileInjections, config.FileInjection{
 			HostPath:    hostPathAndDestination[0],
 			Destination: hostPathAndDestination[1],
 		})
 	}
 
-	return FileInjections, nil
+	return fileInjections, nil
 }
 
 func RunServer(httpClient *http.Client, logfile io.Writer) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,6 +1,21 @@
 package config
 
+import "os"
+
 type HostEnvVar struct {
 	Name  string
 	Value string
+}
+
+type FileInjection struct {
+	HostPath    string
+	Destination string
+}
+
+func (f *FileInjection) CheckFileExists() error {
+	if _, err := os.Stat(f.HostPath); err == nil {
+		return nil
+	} else {
+		return err
+	}
 }

--- a/pkg/executors/docker_compose_executor.go
+++ b/pkg/executors/docker_compose_executor.go
@@ -30,15 +30,23 @@ type DockerComposeExecutor struct {
 	mainContainerName         string
 	exposeKvmDevice           bool
 	fileInjections            []config.FileInjection
+	FailOnMissingFiles        bool
 }
 
-func NewDockerComposeExecutor(request *api.JobRequest, logger *eventlogger.Logger, exposeKvmDevice bool, fileInjections []config.FileInjection) *DockerComposeExecutor {
+type DockerComposeExecutorOptions struct {
+	ExposeKvmDevice    bool
+	FileInjections     []config.FileInjection
+	FailOnMissingFiles bool
+}
+
+func NewDockerComposeExecutor(request *api.JobRequest, logger *eventlogger.Logger, options DockerComposeExecutorOptions) *DockerComposeExecutor {
 	return &DockerComposeExecutor{
 		Logger:                    logger,
 		jobRequest:                request,
 		dockerConfiguration:       request.Compose,
-		exposeKvmDevice:           exposeKvmDevice,
-		fileInjections:            fileInjections,
+		exposeKvmDevice:           options.ExposeKvmDevice,
+		fileInjections:            options.FileInjections,
+		FailOnMissingFiles:        options.FailOnMissingFiles,
 		dockerComposeManifestPath: "/tmp/docker-compose.yml",
 		tmpDirectory:              "/tmp/agent-temp-directory", // make a better random name
 
@@ -58,21 +66,37 @@ func (e *DockerComposeExecutor) Prepare() int {
 		return 1
 	}
 
-	for _, fileInjection := range e.fileInjections {
-		err := fileInjection.CheckFileExists()
-		if err != nil {
-			log.Errorf("Error injecting file %s: %v", fileInjection.HostPath, err)
-			return 1
-		}
+	filesToInject, err := e.findValidFilesToInject()
+	if err != nil {
+		log.Errorf("Error injecting files: %v", err)
+		return 1
 	}
 
-	compose := ConstructDockerComposeFile(e.dockerConfiguration, e.exposeKvmDevice, e.fileInjections)
+	compose := ConstructDockerComposeFile(e.dockerConfiguration, e.exposeKvmDevice, filesToInject)
 	log.Debug("Compose File:")
 	log.Debug(compose)
 
 	ioutil.WriteFile(e.dockerComposeManifestPath, []byte(compose), 0644)
 
 	return e.setUpSSHJumpPoint()
+}
+
+func (e *DockerComposeExecutor) findValidFilesToInject() ([]config.FileInjection, error) {
+	filesToInject := []config.FileInjection{}
+	for _, fileInjection := range e.fileInjections {
+		err := fileInjection.CheckFileExists()
+		if err == nil {
+			filesToInject = append(filesToInject, fileInjection)
+		} else {
+			if e.FailOnMissingFiles {
+				return nil, err
+			} else {
+				log.Warningf("Error injecting file %s - ignoring it: %v", fileInjection.HostPath, err)
+			}
+		}
+	}
+
+	return filesToInject, nil
 }
 
 func (e *DockerComposeExecutor) executeHostCommands() error {

--- a/pkg/executors/docker_compose_executor_test.go
+++ b/pkg/executors/docker_compose_executor_test.go
@@ -49,7 +49,10 @@ func startComposeExecutor() (*DockerComposeExecutor, *eventlogger.Logger, *event
 
 	testLogger, testLoggerBackend := eventlogger.DefaultTestLogger()
 
-	e := NewDockerComposeExecutor(request, testLogger, true, []config.FileInjection{})
+	e := NewDockerComposeExecutor(request, testLogger, DockerComposeExecutorOptions{
+		ExposeKvmDevice: true,
+		FileInjections:  []config.FileInjection{},
+	})
 
 	if code := e.Prepare(); code != 0 {
 		panic("Prapare failed")

--- a/pkg/executors/docker_compose_executor_test.go
+++ b/pkg/executors/docker_compose_executor_test.go
@@ -49,7 +49,7 @@ func startComposeExecutor() (*DockerComposeExecutor, *eventlogger.Logger, *event
 
 	testLogger, testLoggerBackend := eventlogger.DefaultTestLogger()
 
-	e := NewDockerComposeExecutor(request, testLogger, true)
+	e := NewDockerComposeExecutor(request, testLogger, true, []config.FileInjection{})
 
 	if code := e.Prepare(); code != 0 {
 		panic("Prapare failed")

--- a/pkg/executors/docker_compose_file_test.go
+++ b/pkg/executors/docker_compose_file_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	api "github.com/semaphoreci/agent/pkg/api"
+	"github.com/semaphoreci/agent/pkg/config"
 	assert "github.com/stretchr/testify/assert"
 )
 
@@ -58,6 +59,6 @@ services:
 
 `
 
-	compose := ConstructDockerComposeFile(conf, true)
+	compose := ConstructDockerComposeFile(conf, true, []config.FileInjection{})
 	assert.Equal(t, expected, compose)
 }

--- a/pkg/executors/executor.go
+++ b/pkg/executors/executor.go
@@ -21,12 +21,12 @@ type Executor interface {
 const ExecutorTypeShell = "shell"
 const ExecutorTypeDockerCompose = "dockercompose"
 
-func CreateExecutor(request *api.JobRequest, logger *eventlogger.Logger, exposeKvmDevice bool) (Executor, error) {
+func CreateExecutor(request *api.JobRequest, logger *eventlogger.Logger, exposeKvmDevice bool, fileInjections []config.FileInjection) (Executor, error) {
 	switch request.Executor {
 	case ExecutorTypeShell:
 		return NewShellExecutor(request, logger), nil
 	case ExecutorTypeDockerCompose:
-		return NewDockerComposeExecutor(request, logger, exposeKvmDevice), nil
+		return NewDockerComposeExecutor(request, logger, exposeKvmDevice, fileInjections), nil
 	default:
 		return nil, fmt.Errorf("unknown executor type")
 	}

--- a/pkg/executors/executor.go
+++ b/pkg/executors/executor.go
@@ -1,11 +1,8 @@
 package executors
 
 import (
-	"fmt"
-
 	api "github.com/semaphoreci/agent/pkg/api"
 	"github.com/semaphoreci/agent/pkg/config"
-	eventlogger "github.com/semaphoreci/agent/pkg/eventlogger"
 )
 
 type Executor interface {
@@ -20,14 +17,3 @@ type Executor interface {
 
 const ExecutorTypeShell = "shell"
 const ExecutorTypeDockerCompose = "dockercompose"
-
-func CreateExecutor(request *api.JobRequest, logger *eventlogger.Logger, exposeKvmDevice bool, fileInjections []config.FileInjection) (Executor, error) {
-	switch request.Executor {
-	case ExecutorTypeShell:
-		return NewShellExecutor(request, logger), nil
-	case ExecutorTypeDockerCompose:
-		return NewDockerComposeExecutor(request, logger, exposeKvmDevice, fileInjections), nil
-	default:
-		return nil, fmt.Errorf("unknown executor type")
-	}
-}

--- a/pkg/listener/job_processor.go
+++ b/pkg/listener/job_processor.go
@@ -28,6 +28,7 @@ func StartJobProcessor(httpClient *http.Client, apiClient *selfhostedapi.Api, co
 		DisconnectAfterJob:      config.DisconnectAfterJob,
 		EnvVars:                 config.EnvVars,
 		FileInjections:          config.FileInjections,
+		FailOnMissingFiles:      config.FailOnMissingFiles,
 	}
 
 	go p.Start()
@@ -52,6 +53,7 @@ type JobProcessor struct {
 	DisconnectAfterJob      bool
 	EnvVars                 []config.HostEnvVar
 	FileInjections          []config.FileInjection
+	FailOnMissingFiles      bool
 }
 
 func (p *JobProcessor) Start() {
@@ -131,10 +133,11 @@ func (p *JobProcessor) RunJob(jobID string) {
 	}
 
 	job, err := jobs.NewJobWithOptions(&jobs.JobOptions{
-		Request:         jobRequest,
-		Client:          p.HttpClient,
-		ExposeKvmDevice: false,
-		FileInjections:  p.FileInjections,
+		Request:            jobRequest,
+		Client:             p.HttpClient,
+		ExposeKvmDevice:    false,
+		FileInjections:     p.FileInjections,
+		FailOnMissingFiles: p.FailOnMissingFiles,
 	})
 
 	if err != nil {

--- a/pkg/listener/listener.go
+++ b/pkg/listener/listener.go
@@ -29,6 +29,7 @@ type Config struct {
 	DisconnectAfterJob bool
 	EnvVars            []config.HostEnvVar
 	FileInjections     []config.FileInjection
+	FailOnMissingFiles bool
 }
 
 func Start(httpClient *http.Client, config Config, logger io.Writer) (*Listener, error) {

--- a/pkg/listener/listener.go
+++ b/pkg/listener/listener.go
@@ -28,6 +28,7 @@ type Config struct {
 	ShutdownHookPath   string
 	DisconnectAfterJob bool
 	EnvVars            []config.HostEnvVar
+	FileInjections     []config.FileInjection
 }
 
 func Start(httpClient *http.Client, config Config, logger io.Writer) (*Listener, error) {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -13,6 +13,7 @@ import (
 	mux "github.com/gorilla/mux"
 
 	api "github.com/semaphoreci/agent/pkg/api"
+	"github.com/semaphoreci/agent/pkg/config"
 	eventlogger "github.com/semaphoreci/agent/pkg/eventlogger"
 	jobs "github.com/semaphoreci/agent/pkg/jobs"
 	log "github.com/sirupsen/logrus"
@@ -193,7 +194,12 @@ func (s *Server) Run(w http.ResponseWriter, r *http.Request) {
 	}
 
 	log.Debug("Creating new job")
-	job, err := jobs.NewJob(request, s.HttpClient, true)
+	job, err := jobs.NewJobWithOptions(&jobs.JobOptions{
+		Request:         request,
+		Client:          s.HttpClient,
+		ExposeKvmDevice: true,
+		FileInjections:  []config.FileInjection{},
+	})
 
 	if err != nil {
 		log.Errorf("Failed to create a new job, returning 500: %v", err)


### PR DESCRIPTION
The `--files` option takes a comma separated list of file injections in the form `/host/file:/container/file`. For example:

```
/opt/semaphore/agent start \
  --files /opt/semaphore/test.txt:/tmp/test.txt \
  --endpoint ... \
  --token ...
```

- Example job: https://semaphore.semaphoreci.com/jobs/fbafcc7b-8529-4d64-be2f-6e7710bfea33

### Bad arguments

If the option doesn't receive the proper format, the agent won't start up. For example:

```
/opt/semaphore/agent start \
  --files /opt/semaphore/test.txt:/tmp/test.txt,asdasdasd \
  --endpoint ... \
  --token ...
```

gives the following error:

```
Aug  5 18:47:26.073 : Error parsing --files: asdasdasd is not a valid file injection
```

### Files not present in host

By default, If files passed in `--files` are not present in the host, they are ignored and not injected. If the user wants to fail the job in this scenario, they use the `--fail-on-missing-files` flag:

```
/opt/semaphore/agent start \
  --files /opt/semaphore/test.txt:/tmp/test.txt,/opt/semaphore/doesnotexist:/tmp/doesnotexist \
  --fail-on-missing-files \
  --endpoint ... \
  --token ...
```

causes the job to fail:

```
Aug  5 18:39:17.215 : SYNC response (action: run-job, job: 466fa57a-2af2-49c7-ae68-f7591bc963d6)
Aug  5 18:39:17.246 : Running job
Aug  5 18:39:17.246 : Error injecting file /opt/semaphore/doesnotexist: stat /opt/semaphore/doesnotexist: no such file or directory
Aug  5 18:39:17.246 : Failed to prepare executor
Aug  5 18:39:17.246 : Executor failed to boot up
Aug  5 18:39:17.246 : Sending finished callback: {"result": "failed"}
Aug  5 18:39:17.308 : All logs successfully pushed to https://semaphore.semaphoreci.com/api/v1/logs/466fa57a-2af2-49c7-ae68-f7591bc963d6
Aug  5 18:39:17.308 : Sending teardown finished callback
Aug  5 18:39:17.342 : Job teardown finished
Aug  5 18:39:22.216 : SYNC request (state: finished-job, job: 466fa57a-2af2-49c7-ae68-f7591bc963d6)
Aug  5 18:39:22.232 : SYNC response (action: wait-for-jobs, job: )
```

While if you don't use the `--fail-on-missing-files` flag, you'd get:

```
Aug  5 22:21:19.114 : SYNC response (action: run-job, job: 9ab7e6eb-a83c-4b98-9497-950f76d1b4c2)
Aug  5 22:21:19.138 : Running job
Aug  5 22:21:19.139 : Error injecting file /opt/semaphore/notexisting - ignoring it: stat /opt/semaphore/notexisting: no such file or directory
Aug  5 22:21:20.531 : Docker pull finished. Exit Code: 0
Aug  5 22:21:23.786 : Regular commands finished successfully
Aug  5 22:21:23.790 : Starting epilogue always commands
Aug  5 22:21:23.790 : Starting epilogue on pass commands
Aug  5 22:21:23.790 : Sending finished callback: {"result": "passed"}
Aug  5 22:21:23.840 : All logs successfully pushed to https://semaphore.semaphoreci.com/api/v1/logs/9ab7e6eb-a83c-4b98-9497-950f76d1b4c2
Aug  5 22:21:23.840 : Sending teardown finished callback
Aug  5 22:21:23.878 : Job teardown finished
Aug  5 22:21:24.115 : SYNC request (state: finished-job, job: 9ab7e6eb-a83c-4b98-9497-950f76d1b4c2)
Aug  5 22:21:24.128 : SYNC response (action: wait-for-jobs, job: )
```

This scenario also lead me to [this issue](https://github.com/renderedtext/front/pull/1422) in front.