### PR TITLE
Fix bad creds E2Es

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -70,6 +70,8 @@ blocks:
       epilogue:
         commands:
           - docker exec -ti agent cat /tmp/agent_log
+          - docker logs e2e_support_agent_1
+          - docker logs e2e_support_hub_1
 
       jobs:
         - name: Shell
@@ -125,6 +127,8 @@ blocks:
       epilogue:
         commands:
           - docker exec -ti agent cat /tmp/agent_log
+          - docker logs e2e_support_agent_1
+          - docker logs e2e_support_hub_1
 
       jobs:
         - name: Docker
@@ -186,6 +190,13 @@ blocks:
           - go get
           - go build
           - mkdir /tmp/agent
+
+      epilogue:
+        commands:
+          - docker exec -ti agent cat /tmp/agent_log
+          - docker logs e2e_support_agent_1
+          - docker logs e2e_support_hub_1
+
       jobs:
         - name: Self hosted
           commands:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -6,7 +6,7 @@ agent:
     os_image: ubuntu1804
 
 execution_time_limit:
-  minutes: 10
+  minutes: 15
 
 fail_fast:
   stop:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -69,7 +69,6 @@ blocks:
 
       epilogue:
         commands:
-          - docker exec -ti agent cat /tmp/agent_log
           - docker logs e2e_support_agent_1
           - docker logs e2e_support_hub_1
 
@@ -126,7 +125,6 @@ blocks:
 
       epilogue:
         commands:
-          - docker exec -ti agent cat /tmp/agent_log
           - docker logs e2e_support_agent_1
           - docker logs e2e_support_hub_1
 
@@ -193,7 +191,6 @@ blocks:
 
       epilogue:
         commands:
-          - docker exec -ti agent cat /tmp/agent_log
           - docker logs e2e_support_agent_1
           - docker logs e2e_support_hub_1
 

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -69,8 +69,8 @@ blocks:
 
       epilogue:
         commands:
-          - docker logs e2e_support_agent_1
-          - docker logs e2e_support_hub_1
+          - if [ "$TEST_MODE" = "api" ]; then docker exec -ti agent cat /tmp/agent_log; else docker logs e2e_support_agent_1; fi
+          - if [ "$TEST_MODE" = "api" ]; then echo "No hub"; else docker logs e2e_support_hub_1; fi
 
       jobs:
         - name: Shell
@@ -125,8 +125,8 @@ blocks:
 
       epilogue:
         commands:
-          - docker logs e2e_support_agent_1
-          - docker logs e2e_support_hub_1
+          - if [ "$TEST_MODE" = "api" ]; then docker exec -ti agent cat /tmp/agent_log; else docker logs e2e_support_agent_1; fi
+          - if [ "$TEST_MODE" = "api" ]; then echo "No hub"; else docker logs e2e_support_hub_1; fi
 
       jobs:
         - name: Docker

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -26,7 +26,7 @@ blocks:
           - checkout
 
       jobs:
-        - name: Unit Tests
+        - name: Lint
           commands:
             - go get -u github.com/mgechev/revive
             - make lint

--- a/test/e2e/docker/docker_private_image_gcr_bad_creds.rb
+++ b/test/e2e/docker/docker_private_image_gcr_bad_creds.rb
@@ -55,7 +55,7 @@ assert_job_log <<-LOG
   {"directive":"Setting up image pull credentials","event":"cmd_started","timestamp":"*"}
   {"event":"cmd_output","output":"Setting up credentials for GCR\\n","timestamp":"*"}
   {"event":"cmd_output","output":"cat /tmp/gcr/keyfile.json | docker login -u _json_key --password-stdin https://$GCR_HOSTNAME\\n","timestamp":"*"}
-  {"event":"cmd_output","output":"Error response from daemon: Get "https://gcr.io/v2/": unauthorized: GCR login failed. You may have invalid credentials. To login successfully, follow the steps in: https://cloud.google.com/container-registry/docs/advanced-authentication\\n","timestamp":"*"}
+  {"event":"cmd_output","output":"Error response from daemon: Get \"https://gcr.io/v2/\": unauthorized: GCR login failed. You may have invalid credentials. To login successfully, follow the steps in: https://cloud.google.com/container-registry/docs/advanced-authentication\\n","timestamp":"*"}
   {"event":"cmd_output","output":"\\n","timestamp":"*"}
   {"directive":"Setting up image pull credentials","event":"cmd_finished","exit_code":1,"finished_at":"*","started_at":"*","timestamp":"*"}
   {"event":"job_finished","result":"failed","timestamp":"*"}

--- a/test/e2e/docker/docker_private_image_gcr_bad_creds.rb
+++ b/test/e2e/docker/docker_private_image_gcr_bad_creds.rb
@@ -55,7 +55,7 @@ assert_job_log <<-LOG
   {"directive":"Setting up image pull credentials","event":"cmd_started","timestamp":"*"}
   {"event":"cmd_output","output":"Setting up credentials for GCR\\n","timestamp":"*"}
   {"event":"cmd_output","output":"cat /tmp/gcr/keyfile.json | docker login -u _json_key --password-stdin https://$GCR_HOSTNAME\\n","timestamp":"*"}
-  {"event":"cmd_output","output":"Error response from daemon: Get https://gcr.io/v2/: unauthorized: GCR login failed. You may have invalid credentials. To login successfully, follow the steps in: https://cloud.google.com/container-registry/docs/advanced-authentication\\n","timestamp":"*"}
+  {"event":"cmd_output","output":"Error response from daemon: Get "https://gcr.io/v2/": unauthorized: GCR login failed. You may have invalid credentials. To login successfully, follow the steps in: https://cloud.google.com/container-registry/docs/advanced-authentication\\n","timestamp":"*"}
   {"event":"cmd_output","output":"\\n","timestamp":"*"}
   {"directive":"Setting up image pull credentials","event":"cmd_finished","exit_code":1,"finished_at":"*","started_at":"*","timestamp":"*"}
   {"event":"job_finished","result":"failed","timestamp":"*"}

--- a/test/e2e/docker/docker_private_image_gcr_bad_creds.rb
+++ b/test/e2e/docker/docker_private_image_gcr_bad_creds.rb
@@ -55,7 +55,7 @@ assert_job_log <<-LOG
   {"directive":"Setting up image pull credentials","event":"cmd_started","timestamp":"*"}
   {"event":"cmd_output","output":"Setting up credentials for GCR\\n","timestamp":"*"}
   {"event":"cmd_output","output":"cat /tmp/gcr/keyfile.json | docker login -u _json_key --password-stdin https://$GCR_HOSTNAME\\n","timestamp":"*"}
-  {"event":"cmd_output","output":"Error response from daemon: Get \"https://gcr.io/v2/\": unauthorized: GCR login failed. You may have invalid credentials. To login successfully, follow the steps in: https://cloud.google.com/container-registry/docs/advanced-authentication\\n","timestamp":"*"}
+  {"event":"cmd_output","output":"Error response from daemon: Get \\"https://gcr.io/v2/\\": unauthorized: GCR login failed. You may have invalid credentials. To login successfully, follow the steps in: https://cloud.google.com/container-registry/docs/advanced-authentication\\n","timestamp":"*"}
   {"event":"cmd_output","output":"\\n","timestamp":"*"}
   {"directive":"Setting up image pull credentials","event":"cmd_finished","exit_code":1,"finished_at":"*","started_at":"*","timestamp":"*"}
   {"event":"job_finished","result":"failed","timestamp":"*"}

--- a/test/e2e/docker/dockerhub_private_image_bad_creds.rb
+++ b/test/e2e/docker/dockerhub_private_image_bad_creds.rb
@@ -54,7 +54,7 @@ assert_job_log <<-LOG
   {"event":"cmd_started",  "timestamp":"*", "directive":"Setting up image pull credentials"}
   {"event":"cmd_output",   "timestamp":"*", "output":"Setting up credentials for DockerHub\\n"}
   {"event":"cmd_output",   "timestamp":"*", "output":"echo $DOCKERHUB_PASSWORD | docker login --username $DOCKERHUB_USERNAME --password-stdin\\n"}
-  {"event":"cmd_output",   "timestamp":"*", "output":"Error response from daemon: Get https://registry-1.docker.io/v2/: unauthorized: incorrect username or password\\n"}
+  {"event":"cmd_output",   "timestamp":"*", "output":"Error response from daemon: Get "https://registry-1.docker.io/v2/": unauthorized: incorrect username or password\\n"}
   {"event":"cmd_output",   "timestamp":"*", "output":"\\n"}
 
   {"event":"cmd_finished", "timestamp":"*", "directive":"Setting up image pull credentials", "event":"cmd_finished","exit_code":1,"finished_at":"*","started_at":"*","timestamp":"*"}

--- a/test/e2e/docker/dockerhub_private_image_bad_creds.rb
+++ b/test/e2e/docker/dockerhub_private_image_bad_creds.rb
@@ -54,7 +54,7 @@ assert_job_log <<-LOG
   {"event":"cmd_started",  "timestamp":"*", "directive":"Setting up image pull credentials"}
   {"event":"cmd_output",   "timestamp":"*", "output":"Setting up credentials for DockerHub\\n"}
   {"event":"cmd_output",   "timestamp":"*", "output":"echo $DOCKERHUB_PASSWORD | docker login --username $DOCKERHUB_USERNAME --password-stdin\\n"}
-  {"event":"cmd_output",   "timestamp":"*", "output":"Error response from daemon: Get \"https://registry-1.docker.io/v2/\": unauthorized: incorrect username or password\\n"}
+  {"event":"cmd_output",   "timestamp":"*", "output":"Error response from daemon: Get \\"https://registry-1.docker.io/v2/\\": unauthorized: incorrect username or password\\n"}
   {"event":"cmd_output",   "timestamp":"*", "output":"\\n"}
 
   {"event":"cmd_finished", "timestamp":"*", "directive":"Setting up image pull credentials", "event":"cmd_finished","exit_code":1,"finished_at":"*","started_at":"*","timestamp":"*"}

--- a/test/e2e/docker/dockerhub_private_image_bad_creds.rb
+++ b/test/e2e/docker/dockerhub_private_image_bad_creds.rb
@@ -54,7 +54,7 @@ assert_job_log <<-LOG
   {"event":"cmd_started",  "timestamp":"*", "directive":"Setting up image pull credentials"}
   {"event":"cmd_output",   "timestamp":"*", "output":"Setting up credentials for DockerHub\\n"}
   {"event":"cmd_output",   "timestamp":"*", "output":"echo $DOCKERHUB_PASSWORD | docker login --username $DOCKERHUB_USERNAME --password-stdin\\n"}
-  {"event":"cmd_output",   "timestamp":"*", "output":"Error response from daemon: Get "https://registry-1.docker.io/v2/": unauthorized: incorrect username or password\\n"}
+  {"event":"cmd_output",   "timestamp":"*", "output":"Error response from daemon: Get \"https://registry-1.docker.io/v2/\": unauthorized: incorrect username or password\\n"}
   {"event":"cmd_output",   "timestamp":"*", "output":"\\n"}
 
   {"event":"cmd_finished", "timestamp":"*", "directive":"Setting up image pull credentials", "event":"cmd_finished","exit_code":1,"finished_at":"*","started_at":"*","timestamp":"*"}


### PR DESCRIPTION
For some reason, quotes are being added to the the URL now.

GCR:
```
actual   -> Error response from daemon: Get \"https://gcr.io/v2/\": unauthorized: GCR login failed. You may have invalid credentials. To login successfully, follow the steps in: https://cloud.google.com/container-registry/docs/advanced-authentication\n
expected -> Error response from daemon: Get https://gcr.io/v2/: unauthorized: GCR login failed. You may have invalid credentials. To login successfully, follow the steps in: https://cloud.google.com/container-registry/docs/advanced-authentication\n
```

Docker registry:
```
actual   -> Error response from daemon: Get \"https://registry-1.docker.io/v2/\": unauthorized: incorrect username or password\n"
expected -> Error response from daemon: Get https://registry-1.docker.io/v2/: unauthorized: incorrect username or password\n"
```