### PR TITLE
Install script improvements

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-AGENT_INSTALLATION_DIRECTORY=$(pwd)
+AGENT_INSTALLATION_DIRECTORY="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 LOGGED_IN_USER=$(logname)
 
 if [[ "$EUID" -ne 0 ]]; then


### PR DESCRIPTION
- The `config.yaml` is placed in the same directory the `install.sh` is in. Before this, `sudo /opt/semaphore/agent/install.sh` would place the `config.yaml` in the wrong place
- The script doesn't choke if there's a current installation of the agent. Instead, it overrides it