### PR TITLE
Fix goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -35,7 +35,7 @@ changelog:
     - Merge branch
 
 brews:
-  - github:
+  - tap:
       owner: semaphoreci
       name: homebrew-tap
     folder: Formula


### PR DESCRIPTION
Just porting [this fix](https://github.com/semaphoreci/agent/commit/dbcad804130204b49c6984e5a536119dd4247747) to master.