### PR TITLE
Set commit_author for goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -43,6 +43,9 @@ brews:
   - tap:
       owner: semaphoreci
       name: homebrew-tap
+    commit_author:
+      name: release-bot-agent
+      email: contact+release-bot-agent@renderedtext.com
     folder: Formula
     homepage:  https://semaphoreci.com
     description: Semaphore 2.0 agent.


### PR DESCRIPTION
Based on goReleaser's [docs](https://goreleaser.com/customization/homebrew/#:~:text=Git%20author%20used%20to%20commit%20to%20the%20repository).