### PR TITLE
Include additional env vars on installation script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -4,7 +4,6 @@ set -e
 set -o pipefail
 
 AGENT_INSTALLATION_DIRECTORY="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-LOGGED_IN_USER=$(logname)
 
 if [[ "$EUID" -ne 0 ]]; then
   echo "Please run with sudo."
@@ -28,6 +27,7 @@ if [[ -z $SEMAPHORE_REGISTRATION_TOKEN ]]; then
 fi
 
 if [[ -z $SEMAPHORE_AGENT_INSTALLATION_USER ]]; then
+  LOGGED_IN_USER=$(logname)
   read -p "Enter user [$LOGGED_IN_USER]: " SEMAPHORE_AGENT_INSTALLATION_USER
   SEMAPHORE_AGENT_INSTALLATION_USER="${SEMAPHORE_AGENT_INSTALLATION_USER:=$LOGGED_IN_USER}"
 fi

--- a/install.sh
+++ b/install.sh
@@ -111,21 +111,12 @@ if [[ -f "$SYSTEMD_SERVICE_PATH" ]]; then
   echo "systemd service already exists at $SYSTEMD_SERVICE_PATH. Overriding it..."
   echo "$SYSTEMD_SERVICE" > $SYSTEMD_SERVICE_PATH
   systemctl daemon-reload
-
-  if [[ "$SEMAPHORE_AGENT_DO_NOT_START" == "true" ]]; then
-    echo "Not restarting agent."
-  else
-    echo "Restarting semaphore-agent service..."
-    systemctl restart semaphore-agent
-  fi
+  echo "Restarting semaphore-agent service..."
+  systemctl restart semaphore-agent
 else
   echo "$SYSTEMD_SERVICE" > $SYSTEMD_SERVICE_PATH
-  if [[ "$SEMAPHORE_AGENT_DO_NOT_START" == "true" ]]; then
-    echo "Not starting agent."
-  else
-    echo "Starting semaphore-agent service..."
-    systemctl start semaphore-agent
-  fi
+  echo "Starting semaphore-agent service..."
+  systemctl start semaphore-agent
 fi
 
 echo "Done."


### PR DESCRIPTION
New environment variables for installation script:
- `SEMAPHORE_AGENT_DISCONNECT_AFTER_JOB`: default is false
- `SEMAPHORE_AGENT_SHUTDOWN_HOOK`: path to the shutdown hook executed when the agent shuts down

Needed for https://github.com/renderedtext/agent-aws-stack/pull/1