### PR TITLE
Fix grammar mistake while failing to decode file content

### DIFF
--- a/pkg/executors/docker_compose_executor.go
+++ b/pkg/executors/docker_compose_executor.go
@@ -406,7 +406,7 @@ func (e *DockerComposeExecutor) injectImagePullSecretsForGCR(envVars []api.EnvVa
 		content, err := f.Decode()
 
 		if err != nil {
-			e.Logger.LogCommandOutput("Failed to decode content of file.\n")
+			e.Logger.LogCommandOutput("Failed to decode the content of the file.\n")
 			return 1
 		}
 
@@ -628,7 +628,7 @@ func (e *DockerComposeExecutor) InjectFiles(files []api.File) int {
 		content, err := f.Decode()
 
 		if err != nil {
-			e.Logger.LogCommandOutput("Failed to decode content of file.\n")
+			e.Logger.LogCommandOutput("Failed to decode the content of the file.\n")
 			exitCode = 1
 			return exitCode
 		}

--- a/pkg/executors/shell_executor.go
+++ b/pkg/executors/shell_executor.go
@@ -151,7 +151,7 @@ func (e *ShellExecutor) InjectFiles(files []api.File) int {
 
 		content, err := f.Decode()
 		if err != nil {
-			e.Logger.LogCommandOutput("Failed to decode content of file.\n")
+			e.Logger.LogCommandOutput("Failed to decode the content of the file.\n")
 			exitCode = 1
 			return exitCode
 		}


### PR DESCRIPTION
I've noticed this on the call.