### PR TITLE
Allow SEMAPHORE_AGENT_LOG_FILE_PATH to be specified

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -173,7 +173,7 @@ blocks:
                 - container_options
                 - dockerhub_private_image
                 - docker_registry_private_image
-                - docker_private_image_ecr
+                # - docker_private_image_ecr
                 - docker_private_image_gcr
                 - dockerhub_private_image_bad_creds
                 - docker_registry_private_image_bad_creds

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"math/rand"
 	"net/http"
 	"os"
+	"path"
 	"strings"
 	"time"
 
@@ -63,7 +64,7 @@ func main() {
 
 func OpenLogfile() io.Writer {
 	// #nosec
-	f, err := os.OpenFile("/tmp/agent_log", os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0644)
+	f, err := os.OpenFile(getLogFilePath(), os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0644)
 
 	if err != nil {
 		log.Fatal(err)
@@ -84,6 +85,21 @@ func getLogLevel() log.Level {
 	}
 
 	return level
+}
+
+func getLogFilePath() string {
+	logFilePath := os.Getenv("SEMAPHORE_AGENT_LOG_FILE_PATH")
+	if logFilePath == "" {
+		return "/tmp/agent_log"
+	}
+
+	parentDirectory := path.Dir(logFilePath)
+	err := os.MkdirAll(parentDirectory, 0644)
+	if err != nil {
+		log.Panicf("Could not create directories to place log file in '%s': %v", logFilePath, err)
+	}
+
+	return logFilePath
 }
 
 func RunListener(httpClient *http.Client, logfile io.Writer) {


### PR DESCRIPTION
The `docker_private_image_ecr` E2E test was disabled because the AWS credentials required by it are not working anymore. The test has been failing for almost a month.

Once [they are working again](https://github.com/renderedtext/tasks/issues/2662), we can enable this test again.