### PR TITLE
Check error reading environment file

### DIFF
--- a/pkg/shell/process.go
+++ b/pkg/shell/process.go
@@ -160,15 +160,21 @@ func (p *Process) Run() {
 	 * We use a file with all the environment variables available after the command
 	 * is executed. From that file, we can update our shell "state".
 	 */
-	after, _ := CreateEnvironmentFromFile(p.EnvironmentFilePath())
+	after, err := CreateEnvironmentFromFile(p.EnvironmentFilePath())
+	if err != nil {
+		log.Errorf("Error creating environment from file %s: %v\n", p.EnvironmentFilePath(), err)
+		return
+	}
 
 	/*
 	 * CMD.exe does not have an environment variable such as $PWD,
 	 * so we use a custom one to get the current working directory
 	 * after a command is executed.
 	 */
-	newCwd, _ := after.Get("SEMAPHORE_AGENT_CURRENT_DIR")
-	p.Shell.Chdir(newCwd)
+	newCwd, exists := after.Get("SEMAPHORE_AGENT_CURRENT_DIR")
+	if exists {
+		p.Shell.Chdir(newCwd)
+	}
 
 	/*
 	 * We use two custom environment variables to track


### PR DESCRIPTION
For some reason, the environment dump file isn't created in case of some errors. Here's an example from https://semaphore.semaphoreci.com/workflows/856bbbb5-afe0-4513-abac-4bb1c4fe46be?pipeline_id=212dfab6-335d-4174-8f3a-f8d01a45e222:

```
...
Mar 10 23:38:04.176 : Error creating environment from file C:\Users\ADMINI~1\AppData\Local\Temp\2\current-agent-cmd.env.after: open C:\Users\ADMINI~1\AppData\Local\Temp\2\current-agent-cmd.env.after: The system cannot find the file specified.
...
```

This fix makes sure we don't try to do anything else in case the environment file isn't there.