### PR TITLE
fix: update hub reference dependencies

### DIFF
--- a/test/hub_reference/Gemfile.lock
+++ b/test/hub_reference/Gemfile.lock
@@ -1,18 +1,18 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    daemons (1.4.0)
+    daemons (1.4.1)
     eventmachine (1.2.7)
     mustermann (1.1.1)
       ruby2_keywords (~> 0.0.1)
-    rack (2.2.3)
-    rack-protection (2.1.0)
+    rack (2.2.3.1)
+    rack-protection (2.2.0)
       rack
-    ruby2_keywords (0.0.4)
-    sinatra (2.1.0)
+    ruby2_keywords (0.0.5)
+    sinatra (2.2.0)
       mustermann (~> 1.0)
       rack (~> 2.2)
-      rack-protection (= 2.1.0)
+      rack-protection (= 2.2.0)
       tilt (~> 2.0)
     thin (1.8.1)
       daemons (~> 1.0, >= 1.0.9)


### PR DESCRIPTION
This has been failing our builds since a few weeks ago.