### PR TITLE
feat: refresh token used for logs

### DIFF
--- a/pkg/eventlogger/default.go
+++ b/pkg/eventlogger/default.go
@@ -13,12 +13,12 @@ import (
 const LoggerMethodPull = "pull"
 const LoggerMethodPush = "push"
 
-func CreateLogger(request *api.JobRequest) (*Logger, error) {
+func CreateLogger(request *api.JobRequest, refreshTokenFn func() (string, error)) (*Logger, error) {
 	switch request.Logger.Method {
 	case LoggerMethodPull:
 		return Default()
 	case LoggerMethodPush:
-		return DefaultHTTP(request)
+		return DefaultHTTP(request, refreshTokenFn)
 	default:
 		return nil, fmt.Errorf("unknown logger type")
 	}
@@ -44,12 +44,16 @@ func Default() (*Logger, error) {
 	return logger, nil
 }
 
-func DefaultHTTP(request *api.JobRequest) (*Logger, error) {
+func DefaultHTTP(request *api.JobRequest, refreshTokenFn func() (string, error)) (*Logger, error) {
 	if request.Logger.URL == "" {
 		return nil, errors.New("HTTP logger needs a URL")
 	}
 
-	backend, err := NewHTTPBackend(request.Logger.URL, request.Logger.Token)
+	if refreshTokenFn == nil {
+		return nil, errors.New("HTTP logger needs a refresh token function")
+	}
+
+	backend, err := NewHTTPBackend(request.Logger.URL, request.Logger.Token, refreshTokenFn)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/eventlogger/httpbackend_test.go
+++ b/pkg/eventlogger/httpbackend_test.go
@@ -86,8 +86,7 @@ func Test__TokenIsRefreshed(t *testing.T) {
 	// Wait until everything is pushed
 	time.Sleep(2 * time.Second)
 
-	err = httpBackend.Close()
-	assert.Nil(t, err)
+	_ = httpBackend.Close()
 	assert.True(t, tokenWasRefreshed)
 
 	eventObjects, err := TransformToObjects(mockServer.GetLogs())

--- a/pkg/eventlogger/httpbackend_test.go
+++ b/pkg/eventlogger/httpbackend_test.go
@@ -12,7 +12,7 @@ func Test__LogsArePushedToHTTPEndpoint(t *testing.T) {
 	mockServer := testsupport.NewLoghubMockServer()
 	mockServer.Init()
 
-	httpBackend, err := NewHTTPBackend(mockServer.URL(), "token")
+	httpBackend, err := NewHTTPBackend(mockServer.URL(), "token", func() (string, error) { return "", nil })
 	assert.Nil(t, err)
 	assert.Nil(t, httpBackend.Open())
 
@@ -35,6 +35,60 @@ func Test__LogsArePushedToHTTPEndpoint(t *testing.T) {
 
 	err = httpBackend.Close()
 	assert.Nil(t, err)
+
+	eventObjects, err := TransformToObjects(mockServer.GetLogs())
+	assert.Nil(t, err)
+
+	simplifiedEvents, err := SimplifyLogEvents(eventObjects, true)
+	assert.Nil(t, err)
+
+	assert.Equal(t, []string{
+		"job_started",
+
+		"directive: echo hello",
+		"hello\n",
+		"Exit Code: 0",
+
+		"job_finished: passed",
+	}, simplifiedEvents)
+
+	mockServer.Close()
+}
+
+func Test__TokenIsRefreshed(t *testing.T) {
+	mockServer := testsupport.NewLoghubMockServer()
+	mockServer.Init()
+
+	tokenWasRefreshed := false
+
+	httpBackend, err := NewHTTPBackend(mockServer.URL(), testsupport.ExpiredLogToken, func() (string, error) {
+		tokenWasRefreshed = true
+		return "some-new-and-shiny-valid-token", nil
+	})
+
+	assert.Nil(t, err)
+	assert.Nil(t, httpBackend.Open())
+
+	timestamp := int(time.Now().Unix())
+	assert.Nil(t, httpBackend.Write(&JobStartedEvent{Timestamp: timestamp, Event: "job_started"}))
+	assert.Nil(t, httpBackend.Write(&CommandStartedEvent{Timestamp: timestamp, Event: "cmd_started", Directive: "echo hello"}))
+	assert.Nil(t, httpBackend.Write(&CommandOutputEvent{Timestamp: timestamp, Event: "cmd_output", Output: "hello\n"}))
+	assert.Nil(t, httpBackend.Write(&CommandFinishedEvent{
+		Timestamp:  timestamp,
+		Event:      "cmd_finished",
+		Directive:  "echo hello",
+		ExitCode:   0,
+		StartedAt:  timestamp,
+		FinishedAt: timestamp,
+	}))
+	assert.Nil(t, httpBackend.Write(&JobFinishedEvent{Timestamp: timestamp, Event: "job_finished", Result: "passed"}))
+
+	// Wait until everything is pushed
+	time.Sleep(2 * time.Second)
+
+	err = httpBackend.Close()
+	assert.Nil(t, err)
+	assert.True(t, tokenWasRefreshed)
 
 	eventObjects, err := TransformToObjects(mockServer.GetLogs())
 	assert.Nil(t, err)

--- a/pkg/jobs/job.go
+++ b/pkg/jobs/job.go
@@ -40,6 +40,7 @@ type JobOptions struct {
 	FileInjections     []config.FileInjection
 	FailOnMissingFiles bool
 	SelfHosted         bool
+	RefreshTokenFn     func() (string, error)
 }
 
 func NewJob(request *api.JobRequest, client *http.Client) (*Job, error) {
@@ -50,6 +51,7 @@ func NewJob(request *api.JobRequest, client *http.Client) (*Job, error) {
 		FileInjections:     []config.FileInjection{},
 		FailOnMissingFiles: false,
 		SelfHosted:         false,
+		RefreshTokenFn:     nil,
 	})
 }
 
@@ -76,7 +78,7 @@ func NewJobWithOptions(options *JobOptions) (*Job, error) {
 	if options.Logger != nil {
 		job.Logger = options.Logger
 	} else {
-		l, err := eventlogger.CreateLogger(options.Request)
+		l, err := eventlogger.CreateLogger(options.Request, options.RefreshTokenFn)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/listener/job_processor.go
+++ b/pkg/listener/job_processor.go
@@ -182,6 +182,9 @@ func (p *JobProcessor) RunJob(jobID string) {
 		FileInjections:     p.FileInjections,
 		FailOnMissingFiles: p.FailOnMissingFiles,
 		SelfHosted:         true,
+		RefreshTokenFn: func() (string, error) {
+			return p.APIClient.RefreshToken()
+		},
 	})
 
 	if err != nil {

--- a/pkg/listener/selfhostedapi/refresh_token.go
+++ b/pkg/listener/selfhostedapi/refresh_token.go
@@ -1,0 +1,53 @@
+package selfhostedapi
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	log "github.com/sirupsen/logrus"
+)
+
+type RefreshTokenResponse struct {
+	Token string `json:"token"`
+}
+
+func (a *API) RefreshTokenPath() string {
+	return a.BasePath() + "/refresh"
+}
+
+func (a *API) RefreshToken() (string, error) {
+	r, err := http.NewRequest("POST", a.RefreshTokenPath(), nil)
+	if err != nil {
+		return "", err
+	}
+
+	log.Info("Refreshing token for current job logs...")
+
+	a.authorize(r, a.AccessToken)
+
+	resp, err := a.client.Do(r)
+	if err != nil {
+		return "", err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("failed to refresh token, got HTTP %d", resp.StatusCode)
+	}
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	defer resp.Body.Close()
+
+	response := &RefreshTokenResponse{}
+	if err := json.Unmarshal(body, response); err != nil {
+		return "", err
+	}
+
+	log.Infof("Successfully refreshed token for current job logs.")
+	return response.Token, nil
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -211,6 +211,7 @@ func (s *Server) Run(w http.ResponseWriter, r *http.Request) {
 		ExposeKvmDevice: true,
 		FileInjections:  []config.FileInjection{},
 		SelfHosted:      false,
+		RefreshTokenFn:  nil,
 	})
 
 	if err != nil {

--- a/test/support/hub.go
+++ b/test/support/hub.go
@@ -28,6 +28,7 @@ type HubMockServer struct {
 	Disconnected              bool
 	RunningJob                bool
 	FinishedJob               bool
+	TokenIsRefreshed          bool
 	FailureStatus             string
 }
 
@@ -50,10 +51,29 @@ func (m *HubMockServer) Init() {
 			w.WriteHeader(200)
 		case strings.Contains(path, "/jobs/"):
 			m.handleGetJobRequest(w, r)
+		case strings.Contains(path, "/refresh"):
+			m.handleRefreshRequest(w, r)
 		}
 	}))
 
 	m.Server = mockServer
+}
+
+func (m *HubMockServer) handleRefreshRequest(w http.ResponseWriter, r *http.Request) {
+	fmt.Printf("[HUB MOCK] Received refresh request.\n")
+	refreshTokenResponse := &selfhostedapi.RefreshTokenResponse{
+		Token: "new-token",
+	}
+
+	response, err := json.Marshal(refreshTokenResponse)
+	if err != nil {
+		fmt.Printf("[HUB MOCK] Error marshaling refresh response: %v\n", err)
+		w.WriteHeader(500)
+		return
+	}
+
+	m.TokenIsRefreshed = true
+	_, _ = w.Write(response)
 }
 
 func (m *HubMockServer) handleRegisterRequest(w http.ResponseWriter, r *http.Request) {

--- a/test/support/loghub.go
+++ b/test/support/loghub.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 )
 
+const ExpiredLogToken = "expired-token"
+
 type LoghubMockServer struct {
 	Logs    []string
 	Server  *httptest.Server
@@ -21,23 +23,46 @@ func NewLoghubMockServer() *LoghubMockServer {
 }
 
 func (m *LoghubMockServer) Init() {
-	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == http.MethodPost {
-			fmt.Println("[LOGHUB MOCK] Received logs")
-			body, err := ioutil.ReadAll(r.Body)
-			if err != nil {
-				fmt.Printf("Error reading body: %v\n", err)
-			}
-
-			logs := strings.Split(string(body), "\n")
-			m.Logs = append(m.Logs, FilterEmpty(logs)...)
-			w.WriteHeader(200)
-		} else {
-			fmt.Println("NOPE")
-		}
-	}))
-
+	mockServer := httptest.NewServer(http.HandlerFunc(m.handler))
 	m.Server = mockServer
+}
+
+func (m *LoghubMockServer) handler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+
+	// just an easy way to mock the expired token scenario
+	token, err := m.findToken(r)
+	if err != nil || token == ExpiredLogToken {
+		w.WriteHeader(http.StatusUnauthorized)
+		return
+	}
+
+	fmt.Println("[LOGHUB MOCK] Received logs")
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		fmt.Printf("Error reading body: %v\n", err)
+	}
+
+	logs := strings.Split(string(body), "\n")
+	m.Logs = append(m.Logs, FilterEmpty(logs)...)
+	w.WriteHeader(200)
+}
+
+func (m *LoghubMockServer) findToken(r *http.Request) (string, error) {
+	reqToken := r.Header.Get("Authorization")
+	if reqToken == "" {
+		return "", fmt.Errorf("no token found")
+	}
+
+	splitToken := strings.Split(reqToken, "Bearer ")
+	if len(splitToken) != 2 {
+		return "", fmt.Errorf("malformed token")
+	}
+
+	return splitToken[1], nil
 }
 
 func (m *LoghubMockServer) GetLogs() []string {


### PR DESCRIPTION
The tokens generated for agents to push logs to the Semaphore API have a short duration. Currently, if a job takes longer than the duration of the token, the job will proceed as usual, but the logs will be incomplete.

In order to address this, the agent needs to refresh the token. So now, if the agent gets a 401 when trying to push logs to the Semaphore API, it will refresh the token and try again.