### PR TITLE
build: update goreleaser configuration

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -27,7 +27,6 @@ builds:
     - 386
     - amd64
     - arm
-    - arm64
 
 archives:
   - id: non-windows-archive


### PR DESCRIPTION
`windows/arm64` is not supported in Go 1.16. Previously, goreleaser emitted a warning and just didn't generate a binary. Now, it shows an error and doesn't proceed. Here, we just update the goreleaser config to not request a windows/arm64 binary, since one was not being generated anyway.