### PR TITLE
fix: limit the amount of logs per request

### DIFF
--- a/pkg/eventlogger/default.go
+++ b/pkg/eventlogger/default.go
@@ -53,7 +53,13 @@ func DefaultHTTP(request *api.JobRequest, refreshTokenFn func() (string, error))
 		return nil, errors.New("HTTP logger needs a refresh token function")
 	}
 
-	backend, err := NewHTTPBackend(request.Logger.URL, request.Logger.Token, refreshTokenFn)
+	backend, err := NewHTTPBackend(HTTPBackendConfig{
+		URL:             request.Logger.URL,
+		Token:           request.Logger.Token,
+		RefreshTokenFn:  refreshTokenFn,
+		LinesPerRequest: 2000,
+	})
+
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/eventlogger/default.go
+++ b/pkg/eventlogger/default.go
@@ -54,10 +54,11 @@ func DefaultHTTP(request *api.JobRequest, refreshTokenFn func() (string, error))
 	}
 
 	backend, err := NewHTTPBackend(HTTPBackendConfig{
-		URL:             request.Logger.URL,
-		Token:           request.Logger.Token,
-		RefreshTokenFn:  refreshTokenFn,
-		LinesPerRequest: 2000,
+		URL:                   request.Logger.URL,
+		Token:                 request.Logger.Token,
+		RefreshTokenFn:        refreshTokenFn,
+		LinesPerRequest:       MaxLinesPerRequest,
+		FlushTimeoutInSeconds: DefaultFlushTimeoutInSeconds,
 	})
 
 	if err != nil {

--- a/pkg/eventlogger/filebackend.go
+++ b/pkg/eventlogger/filebackend.go
@@ -67,34 +67,43 @@ func (l *FileBackend) Close() error {
 	return nil
 }
 
-func (l *FileBackend) Stream(startLine int, writer io.Writer) (int, error) {
+func (l *FileBackend) Stream(startingLineNumber, maxLines int, writer io.Writer) (int, error) {
 	fd, err := os.OpenFile(l.path, os.O_RDONLY, os.ModePerm)
 	if err != nil {
-		return startLine, err
+		return startingLineNumber, err
 	}
 
 	reader := bufio.NewReader(fd)
-	lineIndex := 0
+	lineNumber := 0
+	linesStreamed := 0
 
 	for {
 		line, err := reader.ReadString('\n')
 		if err != nil {
 			if err != io.EOF {
 				_ = fd.Close()
-				return lineIndex, err
+				return lineNumber, err
 			}
 
 			break
 		}
 
-		if lineIndex < startLine {
-			lineIndex++
+		// If current line is before the starting line we are after, we just skip it.
+		if lineNumber < startingLineNumber {
+			lineNumber++
 			continue
-		} else {
-			lineIndex++
-			fmt.Fprintln(writer, line)
+		}
+
+		// Otherwise, we advance to the next line and stream the current line.
+		lineNumber++
+		fmt.Fprintln(writer, line)
+		linesStreamed++
+
+		// if we have streamed the number of lines we want, we stop.
+		if linesStreamed == maxLines {
+			break
 		}
 	}
 
-	return lineIndex, fd.Close()
+	return lineNumber, fd.Close()
 }

--- a/pkg/eventlogger/httpbackend.go
+++ b/pkg/eventlogger/httpbackend.go
@@ -2,6 +2,7 @@ package eventlogger
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -13,13 +14,27 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+const (
+	// pushing logs while backend is open
+	statePushing = "pushing"
+
+	// pushing logs after backend was requested to be closed
+	stateFlushing = "flushing"
+
+	// stopped pushing logs after a "no more space" response from the API
+	stateStopped = "stopped"
+
+	// all logs were completely streamed to the API
+	stateDone = "done"
+)
+
 type HTTPBackend struct {
 	client      *http.Client
 	fileBackend FileBackend
 	startFrom   int
-	streamChan  chan bool
 	pushLock    sync.Mutex
 	config      HTTPBackendConfig
+	state       string
 }
 
 type HTTPBackendConfig struct {
@@ -41,9 +56,10 @@ func NewHTTPBackend(config HTTPBackendConfig) (*HTTPBackend, error) {
 		fileBackend: *fileBackend,
 		startFrom:   0,
 		config:      config,
+		state:       statePushing,
 	}
 
-	httpBackend.startPushingLogs()
+	go httpBackend.push()
 
 	return &httpBackend, nil
 }
@@ -56,39 +72,46 @@ func (l *HTTPBackend) Write(event interface{}) error {
 	return l.fileBackend.Write(event)
 }
 
-func (l *HTTPBackend) startPushingLogs() {
-	log.Debugf("Logs will be pushed to %s", l.config.URL)
-
-	ticker := time.NewTicker(time.Second)
-	l.streamChan = make(chan bool)
-
-	go func() {
-		for {
-			select {
-			case <-ticker.C:
-				err := l.pushLogs()
-				if err != nil {
-					log.Errorf("Error pushing logs: %v", err)
-					// we don't retry the request here because a new one will happen in 1s,
-					// so we only retry these requests on Close()
-				}
-			case <-l.streamChan:
-				ticker.Stop()
-				return
-			}
-		}
-	}()
-}
-
-func (l *HTTPBackend) stopStreaming() {
-	if l.streamChan != nil {
-		close(l.streamChan)
+// TODO: add noise
+func (l *HTTPBackend) interval() time.Duration {
+	if l.state == stateFlushing {
+		return 500 * time.Millisecond
 	}
 
-	log.Debug("Stopped streaming logs")
+	return time.Second
 }
 
-func (l *HTTPBackend) pushLogs() error {
+func (l *HTTPBackend) push() {
+	log.Infof("Logs will be pushed to %s", l.config.URL)
+
+	for {
+
+		/*
+		 * No more streaming is necessary.
+		 * This happens after the job exhausts the amount of log space it has available.
+		 * The API will simply reject any new requests, so we just stop.
+		 */
+		if l.state == stateStopped || l.state == stateDone {
+			break
+		}
+
+		// wait for the appropriate amount
+		// of time before sending a new request.
+		time.Sleep(l.interval())
+
+		err := l.newRequest()
+		if err != nil {
+			log.Errorf("Error pushing logs: %v", err)
+			// we don't retry the request here because a new one
+			// will happen after a new tick.
+		}
+
+	}
+
+	log.Info("Stopped streaming logs.")
+}
+
+func (l *HTTPBackend) newRequest() error {
 	l.pushLock.Lock()
 	defer l.pushLock.Unlock()
 
@@ -98,14 +121,24 @@ func (l *HTTPBackend) pushLogs() error {
 		return err
 	}
 
+	// We decide what to do when there are
+	// no logs to push based on the current state.
 	if l.startFrom == nextStartFrom {
-		log.Debugf("No logs to push - skipping")
-		// no logs to stream
+
+		// if the current state is flushing,
+		// then the job is done, and no more logs will be written.
+		if l.state == stateFlushing {
+			l.state = stateDone
+			return nil
+		}
+
+		// If not, we just keep streaming.
+		log.Infof("No logs to push - skipping")
 		return nil
 	}
 
 	url := fmt.Sprintf("%s?start_from=%d", l.config.URL, l.startFrom)
-	log.Debugf("Pushing logs to %s", url)
+	log.Infof("Pushing logs to %s", url)
 	request, err := http.NewRequest("POST", url, buffer)
 	if err != nil {
 		return err
@@ -126,6 +159,12 @@ func (l *HTTPBackend) pushLogs() error {
 		l.startFrom = nextStartFrom
 		return nil
 
+	// No more space is available for this job's logs.
+	// The API will keep rejecting the requests if we keep sending them, so just stop.
+	case http.StatusUnprocessableEntity:
+		l.state = stateStopped
+		return errors.New("no more space available for logs - stopping")
+
 	// The token issued for the agent expired.
 	// Try to refresh the token and try again.
 	// Here, we only update the token, and we let the caller do the retrying.
@@ -145,14 +184,24 @@ func (l *HTTPBackend) pushLogs() error {
 }
 
 func (l *HTTPBackend) Close() error {
-	l.stopStreaming()
+	// if logs already stopped being streamed,
+	// there's no need to wait for anything to be flushed.
+	if l.state == stateStopped {
+		return l.fileBackend.Close()
+	}
 
-	err := retry.RetryWithConstantWait("Push logs", 5, time.Second, func() error {
-		return l.pushLogs()
+	l.state = stateFlushing
+	err := retry.RetryWithConstantWait("wait for logs to be flushed", 60, time.Second, func() error {
+		if l.state == stateDone {
+			return nil
+		}
+
+		return fmt.Errorf("logs are not yet fully flushed")
 	})
 
 	if err != nil {
 		log.Errorf("Could not push all logs to %s: %v", l.config.URL, err)
+		l.state = stateStopped
 	} else {
 		log.Infof("All logs successfully pushed to %s", l.config.URL)
 	}

--- a/pkg/eventlogger/httpbackend.go
+++ b/pkg/eventlogger/httpbackend.go
@@ -71,6 +71,8 @@ func (l *HTTPBackend) delay() time.Duration {
 	if l.flush {
 		min := 500
 		max := 1000
+
+		// #nosec
 		interval := rand.Intn(max-min) + min
 		return time.Duration(interval) * time.Millisecond
 	}
@@ -81,6 +83,8 @@ func (l *HTTPBackend) delay() time.Duration {
 	 */
 	min := 1500
 	max := 3000
+
+	// #nosec
 	interval := rand.Intn(max-min) + min
 	return time.Duration(interval) * time.Millisecond
 }

--- a/pkg/eventlogger/httpbackend_test.go
+++ b/pkg/eventlogger/httpbackend_test.go
@@ -8,35 +8,96 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func Test__ArgumentsMustBeValid(t *testing.T) {
+	t.Run("linesPerRequest cannot be unspecified or 0", func(t *testing.T) {
+		backend, err := NewHTTPBackend(HTTPBackendConfig{
+			URL:            "whatever",
+			Token:          "token",
+			RefreshTokenFn: func() (string, error) { return "", nil },
+		})
+
+		assert.Nil(t, backend)
+		assert.ErrorContains(t, err, "must be between 1 and 2000")
+	})
+
+	t.Run("linesPerRequest cannot be negative", func(t *testing.T) {
+		backend, err := NewHTTPBackend(HTTPBackendConfig{
+			URL:             "whatever",
+			Token:           "token",
+			RefreshTokenFn:  func() (string, error) { return "", nil },
+			LinesPerRequest: -1,
+		})
+
+		assert.Nil(t, backend)
+		assert.ErrorContains(t, err, "must be between 1 and 2000")
+	})
+
+	t.Run("linesPerRequest cannot be above the maximum allowed", func(t *testing.T) {
+		backend, err := NewHTTPBackend(HTTPBackendConfig{
+			URL:             "whatever",
+			Token:           "token",
+			RefreshTokenFn:  func() (string, error) { return "", nil },
+			LinesPerRequest: 10000,
+		})
+
+		assert.Nil(t, backend)
+		assert.ErrorContains(t, err, "must be between 1 and 2000")
+	})
+
+	t.Run("FlushTimeoutInSeconds cannot be unspecified or 0", func(t *testing.T) {
+		backend, err := NewHTTPBackend(HTTPBackendConfig{
+			URL:             "whatever",
+			Token:           "token",
+			LinesPerRequest: MaxLinesPerRequest,
+			RefreshTokenFn:  func() (string, error) { return "", nil },
+		})
+
+		assert.Nil(t, backend)
+		assert.ErrorContains(t, err, "must be between 1 and 900")
+	})
+
+	t.Run("FlushTimeoutInSeconds cannot be negative", func(t *testing.T) {
+		backend, err := NewHTTPBackend(HTTPBackendConfig{
+			URL:                   "whatever",
+			Token:                 "token",
+			LinesPerRequest:       MaxLinesPerRequest,
+			FlushTimeoutInSeconds: -1,
+			RefreshTokenFn:        func() (string, error) { return "", nil },
+		})
+
+		assert.Nil(t, backend)
+		assert.ErrorContains(t, err, "must be between 1 and 900")
+	})
+
+	t.Run("FlushTimeoutInSeconds cannot be above the maximum allowed", func(t *testing.T) {
+		backend, err := NewHTTPBackend(HTTPBackendConfig{
+			URL:                   "whatever",
+			Token:                 "token",
+			RefreshTokenFn:        func() (string, error) { return "", nil },
+			LinesPerRequest:       MaxLinesPerRequest,
+			FlushTimeoutInSeconds: 1000000,
+		})
+
+		assert.Nil(t, backend)
+		assert.ErrorContains(t, err, "must be between 1 and 900")
+	})
+}
+
 func Test__LogsArePushedToHTTPEndpoint(t *testing.T) {
 	mockServer := testsupport.NewLoghubMockServer()
 	mockServer.Init()
 
 	httpBackend, err := NewHTTPBackend(HTTPBackendConfig{
-		URL:            mockServer.URL(),
-		Token:          "token",
-		RefreshTokenFn: func() (string, error) { return "", nil },
+		URL:             mockServer.URL(),
+		Token:           "token",
+		RefreshTokenFn:  func() (string, error) { return "", nil },
+		LinesPerRequest: 20,
 	})
 
 	assert.Nil(t, err)
 	assert.Nil(t, httpBackend.Open())
 
-	timestamp := int(time.Now().Unix())
-	assert.Nil(t, httpBackend.Write(&JobStartedEvent{Timestamp: timestamp, Event: "job_started"}))
-	assert.Nil(t, httpBackend.Write(&CommandStartedEvent{Timestamp: timestamp, Event: "cmd_started", Directive: "echo hello"}))
-	assert.Nil(t, httpBackend.Write(&CommandOutputEvent{Timestamp: timestamp, Event: "cmd_output", Output: "hello\n"}))
-	assert.Nil(t, httpBackend.Write(&CommandFinishedEvent{
-		Timestamp:  timestamp,
-		Event:      "cmd_finished",
-		Directive:  "echo hello",
-		ExitCode:   0,
-		StartedAt:  timestamp,
-		FinishedAt: timestamp,
-	}))
-	assert.Nil(t, httpBackend.Write(&JobFinishedEvent{Timestamp: timestamp, Event: "job_finished", Result: "passed"}))
-
-	// Wait until everything is pushed
-	time.Sleep(2 * time.Second)
+	generateLogEvents(t, 1, httpBackend)
 
 	err = httpBackend.Close()
 	assert.Nil(t, err)
@@ -60,6 +121,89 @@ func Test__LogsArePushedToHTTPEndpoint(t *testing.T) {
 	mockServer.Close()
 }
 
+func Test__RequestsAreCappedAtLinesPerRequest(t *testing.T) {
+	mockServer := testsupport.NewLoghubMockServer()
+	mockServer.Init()
+
+	httpBackend, err := NewHTTPBackend(HTTPBackendConfig{
+		URL:             mockServer.URL(),
+		Token:           "token",
+		RefreshTokenFn:  func() (string, error) { return "", nil },
+		LinesPerRequest: 2,
+	})
+
+	assert.Nil(t, err)
+	assert.Nil(t, httpBackend.Open())
+
+	generateLogEvents(t, 10, httpBackend)
+	_ = httpBackend.Close()
+
+	// assert no more than 2 events were sent per batch
+	for _, batchSize := range mockServer.GetBatchSizesUsed() {
+		assert.LessOrEqual(t, batchSize, 2)
+	}
+
+	eventObjects, err := TransformToObjects(mockServer.GetLogs())
+	assert.Nil(t, err)
+
+	simplifiedEvents, err := SimplifyLogEvents(eventObjects, true)
+	assert.Nil(t, err)
+
+	assert.Equal(t, []string{
+		"job_started",
+
+		"directive: echo hello",
+		"hello\n",
+		"hello\n",
+		"hello\n",
+		"hello\n",
+		"hello\n",
+		"hello\n",
+		"hello\n",
+		"hello\n",
+		"hello\n",
+		"hello\n",
+		"Exit Code: 0",
+
+		"job_finished: passed",
+	}, simplifiedEvents)
+
+	mockServer.Close()
+}
+
+func Test__FlushingGivesUpAfterTimeout(t *testing.T) {
+	mockServer := testsupport.NewLoghubMockServer()
+	mockServer.Init()
+
+	httpBackend, err := NewHTTPBackend(HTTPBackendConfig{
+		URL:                   mockServer.URL(),
+		Token:                 "token",
+		RefreshTokenFn:        func() (string, error) { return "", nil },
+		LinesPerRequest:       2,
+		FlushTimeoutInSeconds: 10,
+	})
+
+	assert.Nil(t, err)
+	assert.Nil(t, httpBackend.Open())
+
+	// 1000+ log events at 2 per request
+	// would take more time to flush everything that the timeout we give it.
+	generateLogEvents(t, 1000, httpBackend)
+
+	_ = httpBackend.Close()
+
+	eventObjects, err := TransformToObjects(mockServer.GetLogs())
+	assert.Nil(t, err)
+
+	simplifiedEvents, err := SimplifyLogEvents(eventObjects, true)
+	assert.Nil(t, err)
+
+	// logs are incomplete
+	assert.NotContains(t, simplifiedEvents, "job_finished: passed")
+
+	mockServer.Close()
+}
+
 func Test__TokenIsRefreshed(t *testing.T) {
 	mockServer := testsupport.NewLoghubMockServer()
 	mockServer.Init()
@@ -67,8 +211,9 @@ func Test__TokenIsRefreshed(t *testing.T) {
 	tokenWasRefreshed := false
 
 	httpBackend, err := NewHTTPBackend(HTTPBackendConfig{
-		URL:   mockServer.URL(),
-		Token: testsupport.ExpiredLogToken,
+		URL:             mockServer.URL(),
+		Token:           testsupport.ExpiredLogToken,
+		LinesPerRequest: 20,
 		RefreshTokenFn: func() (string, error) {
 			tokenWasRefreshed = true
 			return "some-new-and-shiny-valid-token", nil
@@ -78,23 +223,7 @@ func Test__TokenIsRefreshed(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Nil(t, httpBackend.Open())
 
-	timestamp := int(time.Now().Unix())
-	assert.Nil(t, httpBackend.Write(&JobStartedEvent{Timestamp: timestamp, Event: "job_started"}))
-	assert.Nil(t, httpBackend.Write(&CommandStartedEvent{Timestamp: timestamp, Event: "cmd_started", Directive: "echo hello"}))
-	assert.Nil(t, httpBackend.Write(&CommandOutputEvent{Timestamp: timestamp, Event: "cmd_output", Output: "hello\n"}))
-	assert.Nil(t, httpBackend.Write(&CommandFinishedEvent{
-		Timestamp:  timestamp,
-		Event:      "cmd_finished",
-		Directive:  "echo hello",
-		ExitCode:   0,
-		StartedAt:  timestamp,
-		FinishedAt: timestamp,
-	}))
-	assert.Nil(t, httpBackend.Write(&JobFinishedEvent{Timestamp: timestamp, Event: "job_finished", Result: "passed"}))
-
-	// Wait until everything is pushed
-	time.Sleep(2 * time.Second)
-
+	generateLogEvents(t, 1, httpBackend)
 	_ = httpBackend.Close()
 	assert.True(t, tokenWasRefreshed)
 
@@ -115,4 +244,28 @@ func Test__TokenIsRefreshed(t *testing.T) {
 	}, simplifiedEvents)
 
 	mockServer.Close()
+}
+
+func generateLogEvents(t *testing.T, outputEventsCount int, backend *HTTPBackend) {
+	timestamp := int(time.Now().Unix())
+
+	assert.Nil(t, backend.Write(&JobStartedEvent{Timestamp: timestamp, Event: "job_started"}))
+	assert.Nil(t, backend.Write(&CommandStartedEvent{Timestamp: timestamp, Event: "cmd_started", Directive: "echo hello"}))
+
+	count := outputEventsCount
+	for count > 0 {
+		assert.Nil(t, backend.Write(&CommandOutputEvent{Timestamp: timestamp, Event: "cmd_output", Output: "hello\n"}))
+		count--
+	}
+
+	assert.Nil(t, backend.Write(&CommandFinishedEvent{
+		Timestamp:  timestamp,
+		Event:      "cmd_finished",
+		Directive:  "echo hello",
+		ExitCode:   0,
+		StartedAt:  timestamp,
+		FinishedAt: timestamp,
+	}))
+
+	assert.Nil(t, backend.Write(&JobFinishedEvent{Timestamp: timestamp, Event: "job_finished", Result: "passed"}))
 }

--- a/pkg/eventlogger/httpbackend_test.go
+++ b/pkg/eventlogger/httpbackend_test.go
@@ -12,7 +12,12 @@ func Test__LogsArePushedToHTTPEndpoint(t *testing.T) {
 	mockServer := testsupport.NewLoghubMockServer()
 	mockServer.Init()
 
-	httpBackend, err := NewHTTPBackend(mockServer.URL(), "token", func() (string, error) { return "", nil })
+	httpBackend, err := NewHTTPBackend(HTTPBackendConfig{
+		URL:            mockServer.URL(),
+		Token:          "token",
+		RefreshTokenFn: func() (string, error) { return "", nil },
+	})
+
 	assert.Nil(t, err)
 	assert.Nil(t, httpBackend.Open())
 
@@ -61,9 +66,13 @@ func Test__TokenIsRefreshed(t *testing.T) {
 
 	tokenWasRefreshed := false
 
-	httpBackend, err := NewHTTPBackend(mockServer.URL(), testsupport.ExpiredLogToken, func() (string, error) {
-		tokenWasRefreshed = true
-		return "some-new-and-shiny-valid-token", nil
+	httpBackend, err := NewHTTPBackend(HTTPBackendConfig{
+		URL:   mockServer.URL(),
+		Token: testsupport.ExpiredLogToken,
+		RefreshTokenFn: func() (string, error) {
+			tokenWasRefreshed = true
+			return "some-new-and-shiny-valid-token", nil
+		},
 	})
 
 	assert.Nil(t, err)

--- a/pkg/eventlogger/httpbackend_test.go
+++ b/pkg/eventlogger/httpbackend_test.go
@@ -88,10 +88,11 @@ func Test__LogsArePushedToHTTPEndpoint(t *testing.T) {
 	mockServer.Init()
 
 	httpBackend, err := NewHTTPBackend(HTTPBackendConfig{
-		URL:             mockServer.URL(),
-		Token:           "token",
-		RefreshTokenFn:  func() (string, error) { return "", nil },
-		LinesPerRequest: 20,
+		URL:                   mockServer.URL(),
+		Token:                 "token",
+		RefreshTokenFn:        func() (string, error) { return "", nil },
+		LinesPerRequest:       20,
+		FlushTimeoutInSeconds: DefaultFlushTimeoutInSeconds,
 	})
 
 	assert.Nil(t, err)
@@ -126,10 +127,11 @@ func Test__RequestsAreCappedAtLinesPerRequest(t *testing.T) {
 	mockServer.Init()
 
 	httpBackend, err := NewHTTPBackend(HTTPBackendConfig{
-		URL:             mockServer.URL(),
-		Token:           "token",
-		RefreshTokenFn:  func() (string, error) { return "", nil },
-		LinesPerRequest: 2,
+		URL:                   mockServer.URL(),
+		Token:                 "token",
+		RefreshTokenFn:        func() (string, error) { return "", nil },
+		LinesPerRequest:       2,
+		FlushTimeoutInSeconds: DefaultFlushTimeoutInSeconds,
 	})
 
 	assert.Nil(t, err)
@@ -211,9 +213,10 @@ func Test__TokenIsRefreshed(t *testing.T) {
 	tokenWasRefreshed := false
 
 	httpBackend, err := NewHTTPBackend(HTTPBackendConfig{
-		URL:             mockServer.URL(),
-		Token:           testsupport.ExpiredLogToken,
-		LinesPerRequest: 20,
+		URL:                   mockServer.URL(),
+		Token:                 testsupport.ExpiredLogToken,
+		LinesPerRequest:       20,
+		FlushTimeoutInSeconds: DefaultFlushTimeoutInSeconds,
 		RefreshTokenFn: func() (string, error) {
 			tokenWasRefreshed = true
 			return "some-new-and-shiny-valid-token", nil

--- a/pkg/jobs/job.go
+++ b/pkg/jobs/job.go
@@ -327,15 +327,25 @@ func (job *Job) Stop() {
 func (job *Job) SendFinishedCallback(result string, retries int) error {
 	payload := fmt.Sprintf(`{"result": "%s"}`, result)
 	log.Infof("Sending finished callback: %+v", payload)
-	return retry.RetryWithConstantWait("Send finished callback", retries, time.Second, func() error {
-		return job.SendCallback(job.Request.Callbacks.Finished, payload)
+	return retry.RetryWithConstantWait(retry.RetryOptions{
+		Task:                 "Send finished callback",
+		MaxAttempts:          retries,
+		DelayBetweenAttempts: time.Second,
+		Fn: func() error {
+			return job.SendCallback(job.Request.Callbacks.Finished, payload)
+		},
 	})
 }
 
 func (job *Job) SendTeardownFinishedCallback(retries int) error {
 	log.Info("Sending teardown finished callback")
-	return retry.RetryWithConstantWait("Send teardown finished callback", retries, time.Second, func() error {
-		return job.SendCallback(job.Request.Callbacks.TeardownFinished, "{}")
+	return retry.RetryWithConstantWait(retry.RetryOptions{
+		Task:                 "Send teardown finished callback",
+		MaxAttempts:          retries,
+		DelayBetweenAttempts: time.Second,
+		Fn: func() error {
+			return job.SendCallback(job.Request.Callbacks.TeardownFinished, "{}")
+		},
 	})
 }
 

--- a/pkg/listener/listener.go
+++ b/pkg/listener/listener.go
@@ -115,14 +115,19 @@ func (l *Listener) Register() error {
 		Hostname: osinfo.Hostname(),
 	}
 
-	err = retry.RetryWithConstantWait("Register", l.Config.RegisterRetryLimit, time.Second, func() error {
-		resp, err := l.Client.Register(req)
-		if err != nil {
-			return err
-		}
+	err = retry.RetryWithConstantWait(retry.RetryOptions{
+		Task:                 "Register",
+		MaxAttempts:          l.Config.RegisterRetryLimit,
+		DelayBetweenAttempts: time.Second,
+		Fn: func() error {
+			resp, err := l.Client.Register(req)
+			if err != nil {
+				return err
+			}
 
-		l.Client.SetAccessToken(resp.Token)
-		return nil
+			l.Client.SetAccessToken(resp.Token)
+			return nil
+		},
 	})
 
 	if err != nil {

--- a/pkg/retry/retry_test.go
+++ b/pkg/retry/retry_test.go
@@ -10,20 +10,32 @@ import (
 
 func Test__NoRetriesIfFirstAttemptIsSuccessful(t *testing.T) {
 	attempts := 0
-	err := RetryWithConstantWait("test", 5, 100*time.Millisecond, func() error {
-		attempts++
-		return nil
+	err := RetryWithConstantWait(RetryOptions{
+		Task:                 "test",
+		MaxAttempts:          5,
+		DelayBetweenAttempts: 100 * time.Millisecond,
+		Fn: func() error {
+			attempts++
+			return nil
+		},
 	})
+
 	assert.Equal(t, attempts, 1)
 	assert.Nil(t, err)
 }
 
 func Test__GivesUpAfterMaxRetries(t *testing.T) {
 	attempts := 0
-	err := RetryWithConstantWait("test", 5, 100*time.Millisecond, func() error {
-		attempts++
-		return errors.New("bad error")
+	err := RetryWithConstantWait(RetryOptions{
+		Task:                 "test",
+		MaxAttempts:          5,
+		DelayBetweenAttempts: 100 * time.Millisecond,
+		Fn: func() error {
+			attempts++
+			return errors.New("bad error")
+		},
 	})
+
 	assert.Equal(t, attempts, 5)
 	assert.NotNil(t, err)
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"math"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -129,7 +130,7 @@ func (s *Server) JobLogs(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, `{"message": "%s"}`, "Failed to open logfile")
 	}
 
-	_, err = logFile.Stream(startFromLine, w)
+	_, err = logFile.Stream(startFromLine, math.MaxInt32, w)
 	if err != nil {
 		log.Errorf("Error while streaming logs: %v", err)
 

--- a/test/support/hub.go
+++ b/test/support/hub.go
@@ -232,52 +232,77 @@ func (m *HubMockServer) Host() string {
 }
 
 func (m *HubMockServer) WaitUntilFailure(status string, attempts int, wait time.Duration) error {
-	return retry.RetryWithConstantWait("WaitUntilRunningJob", attempts, wait, func() error {
-		if m.FailureStatus != status {
-			return fmt.Errorf("still haven't failed with %s", status)
-		}
+	return retry.RetryWithConstantWait(retry.RetryOptions{
+		Task:                 "WaitUntilRunningJob",
+		MaxAttempts:          attempts,
+		DelayBetweenAttempts: wait,
+		Fn: func() error {
+			if m.FailureStatus != status {
+				return fmt.Errorf("still haven't failed with %s", status)
+			}
 
-		return nil
+			return nil
+		},
 	})
 }
 
 func (m *HubMockServer) WaitUntilRunningJob(attempts int, wait time.Duration) error {
-	return retry.RetryWithConstantWait("WaitUntilRunningJob", attempts, wait, func() error {
-		if !m.RunningJob {
-			return fmt.Errorf("still not running job")
-		}
+	return retry.RetryWithConstantWait(retry.RetryOptions{
+		Task:                 "WaitUntilRunningJob",
+		MaxAttempts:          attempts,
+		DelayBetweenAttempts: wait,
+		Fn: func() error {
+			if !m.RunningJob {
+				return fmt.Errorf("still not running job")
+			}
 
-		return nil
+			return nil
+		},
 	})
 }
 
 func (m *HubMockServer) WaitUntilFinishedJob(attempts int, wait time.Duration) error {
-	return retry.RetryWithConstantWait("WaitUntilFinishedJob", attempts, wait, func() error {
-		if !m.FinishedJob {
-			return fmt.Errorf("still not finished job")
-		}
+	return retry.RetryWithConstantWait(retry.RetryOptions{
+		Task:                 "WaitUntilFinishedJob",
+		MaxAttempts:          attempts,
+		DelayBetweenAttempts: wait,
+		Fn: func() error {
+			if !m.FinishedJob {
+				return fmt.Errorf("still not finished job")
+			}
 
-		return nil
+			return nil
+		},
 	})
 }
 
 func (m *HubMockServer) WaitUntilDisconnected(attempts int, wait time.Duration) error {
-	return retry.RetryWithConstantWait("WaitUntilDisconnected", attempts, wait, func() error {
-		if !m.Disconnected {
-			return fmt.Errorf("still not disconnected")
-		}
+	return retry.RetryWithConstantWait(retry.RetryOptions{
+		Task:                 "WaitUntilDisconnected",
+		MaxAttempts:          attempts,
+		DelayBetweenAttempts: wait,
+		Fn: func() error {
+			if !m.Disconnected {
+				return fmt.Errorf("still not disconnected")
+			}
 
-		return nil
+			return nil
+		},
 	})
 }
 
 func (m *HubMockServer) WaitUntilRegistered() error {
-	return retry.RetryWithConstantWait("WaitUntilRegistered", 10, time.Second, func() error {
-		if m.RegisterRequest == nil {
-			return fmt.Errorf("still not registered")
-		}
+	return retry.RetryWithConstantWait(retry.RetryOptions{
+		Task:                 "WaitUntilRegistered",
+		MaxAttempts:          10,
+		DelayBetweenAttempts: time.Second,
+		Fn: func() error {
+			if m.RegisterRequest == nil {
+				return fmt.Errorf("still not registered")
+			}
 
-		return nil
+			return nil
+		},
 	})
 }
 


### PR DESCRIPTION
- Caps the number of log events sent in each log batch to avoid pushing too many logs at a time.
- Stop trying to send logs if the API has indicated that no more space is available to avoid sending unnecessary requests that will be just rejected by the API.
- Add some randomness to the delay we use between each batch. If the job is not finished, we use a wider range of delay between 1500ms and 3000ms. If the job is finished and we are trying to flush all the logs, we use a tighter range between 500ms and 1000ms. This is in order to avoid coordinating requests at the exact same interval.
- When flushing logs after a job is finished, we use a default timeout of 60 seconds. If, after that period, the agent still couldn't flush everything, the agent gives up and leaves the logs incomplete.

## Other unrelated changes

- `retry.RetryWithConstantWait()` was refactored to accept a `RetryOptions` object. This was done to allow a new argument `HideErrors` to be added, to not log errors.

## Example logs

```
Jul 14 13:52:32.367 : SYNC response (action: run-job, job: 633cfea0-f355-4134-89a1-94e752471f29)
Jul 14 13:52:32.868 : No executor specified - using shell executor
Jul 14 13:52:32.868 : Running job
Jul 14 13:52:32.868 : Logs will be pushed to https://semaphore.semaphoreci.com/api/v1/logs/633cfea0-f355-4134-89a1-94e752471f29
Jul 14 13:52:32.871 : Waiting 2.905s to push next batch of logs...
Jul 14 13:52:35.782 : Pushing next batch of logs with 216 log events...
Jul 14 13:52:36.009 : Waiting 2.121s to push next batch of logs...
Jul 14 13:52:37.369 : SYNC request (state: running-job, job: 633cfea0-f355-4134-89a1-94e752471f29)
Jul 14 13:52:37.505 : SYNC response (action: continue, job: )
Jul 14 13:52:38.132 : Pushing next batch of logs with 341 log events...
Jul 14 13:52:38.344 : Waiting 1.654s to push next batch of logs...
Jul 14 13:52:40.001 : Pushing next batch of logs with 3 log events...
Jul 14 13:52:40.134 : Waiting 2.396s to push next batch of logs...
Jul 14 13:52:42.507 : SYNC request (state: running-job, job: 633cfea0-f355-4134-89a1-94e752471f29)
Jul 14 13:52:42.532 : Pushing next batch of logs with 513 log events...
Jul 14 13:52:42.636 : SYNC response (action: continue, job: )
Jul 14 13:52:42.856 : Waiting 2.539s to push next batch of logs...
Jul 14 13:52:45.398 : No logs to push - skipping
Jul 14 13:52:45.398 : Waiting 1.534s to push next batch of logs...
Jul 14 13:52:46.936 : Pushing next batch of logs with 682 log events...
Jul 14 13:52:47.278 : Waiting 2.569s to push next batch of logs...
Jul 14 13:52:47.637 : SYNC request (state: running-job, job: 633cfea0-f355-4134-89a1-94e752471f29)
Jul 14 13:52:47.768 : SYNC response (action: continue, job: )
Jul 14 13:52:49.850 : Pushing next batch of logs with 2000 log events...
Jul 14 13:52:50.346 : Waiting 2.884s to push next batch of logs...
Jul 14 13:52:52.769 : SYNC request (state: running-job, job: 633cfea0-f355-4134-89a1-94e752471f29)
Jul 14 13:52:52.908 : SYNC response (action: continue, job: )
Jul 14 13:52:53.238 : Pushing next batch of logs with 2000 log events...
Jul 14 13:52:53.748 : Waiting 1.933s to push next batch of logs...
Jul 14 13:52:55.689 : Pushing next batch of logs with 2000 log events...
Jul 14 13:52:56.186 : Waiting 2.303s to push next batch of logs...
Jul 14 13:52:57.746 : Regular commands finished successfully
Jul 14 13:52:57.754 : Starting epilogue always commands
Jul 14 13:52:57.754 : Starting epilogue on pass commands
Jul 14 13:52:57.754 : Sending finished callback: {"result": "passed"}
Jul 14 13:52:57.910 : SYNC request (state: running-job, job: 633cfea0-f355-4134-89a1-94e752471f29)
Jul 14 13:52:57.979 : Waiting for all logs to be flushed...
Jul 14 13:52:58.047 : SYNC response (action: continue, job: )
Jul 14 13:52:58.499 : Pushing next batch of logs with 2000 log events...
Jul 14 13:52:59.024 : Waiting 765ms to push next batch of logs...
Jul 14 13:52:59.797 : Pushing next batch of logs with 2000 log events...
Jul 14 13:53:00.280 : Waiting 749ms to push next batch of logs...
Jul 14 13:53:01.038 : Pushing next batch of logs with 1032 log events...
Jul 14 13:53:01.335 : Waiting 698ms to push next batch of logs...
Jul 14 13:53:02.042 : No more logs to flush - stopping
Jul 14 13:53:02.042 : Stopped pushing logs.
Jul 14 13:53:02.983 : Sending teardown finished callback
Jul 14 13:53:03.048 : SYNC request (state: running-job, job: 633cfea0-f355-4134-89a1-94e752471f29)
Jul 14 13:53:03.144 : Job teardown finished
Jul 14 13:53:03.181 : SYNC response (action: continue, job: )
Jul 14 13:53:08.186 : SYNC request (state: finished-job, job: 633cfea0-f355-4134-89a1-94e752471f29)
Jul 14 13:53:08.322 : SYNC response (action: wait-for-jobs, job: )
```