### PR TITLE
fix: use random delay for sync requests

### DIFF
--- a/pkg/eventlogger/httpbackend.go
+++ b/pkg/eventlogger/httpbackend.go
@@ -4,12 +4,12 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"math/rand"
 	"net/http"
 	"os"
 	"path/filepath"
 	"time"
 
+	"github.com/semaphoreci/agent/pkg/random"
 	"github.com/semaphoreci/agent/pkg/retry"
 	log "github.com/sirupsen/logrus"
 )
@@ -122,24 +122,16 @@ func (l *HTTPBackend) delay() time.Duration {
 	 * we use a tighter range of 500ms - 1000ms.
 	 */
 	if l.flush {
-		min := 500
-		max := 1000
-
-		// #nosec
-		interval := rand.Intn(max-min) + min
-		return time.Duration(interval) * time.Millisecond
+		delay, _ := random.DurationInRange(500, 1000)
+		return *delay
 	}
 
 	/*
 	 * if we are not flushing,
 	 * we use a wider range of 1500ms - 3000ms.
 	 */
-	min := 1500
-	max := 3000
-
-	// #nosec
-	interval := rand.Intn(max-min) + min
-	return time.Duration(interval) * time.Millisecond
+	delay, _ := random.DurationInRange(1500, 3000)
+	return *delay
 }
 
 func (l *HTTPBackend) newRequest() error {

--- a/pkg/random/random.go
+++ b/pkg/random/random.go
@@ -1,0 +1,21 @@
+package random
+
+import (
+	"fmt"
+	"math/rand"
+	"time"
+)
+
+func DurationInRange(minMillis, maxMillis int) (*time.Duration, error) {
+	if minMillis <= 0 {
+		return nil, fmt.Errorf("min cannot be less than or equal to zero")
+	}
+
+	if minMillis >= maxMillis {
+		return nil, fmt.Errorf("max cannot be greater than or equal to zero")
+	}
+
+	interval := rand.Intn(maxMillis-minMillis) + minMillis
+	duration := time.Duration(interval) * time.Millisecond
+	return &duration, nil
+}

--- a/pkg/random/random_test.go
+++ b/pkg/random/random_test.go
@@ -1,0 +1,29 @@
+package random
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test__RandomDuration(t *testing.T) {
+	t.Run("min can't be zero or negative", func(t *testing.T) {
+		duration, err := DurationInRange(-1, 0)
+		assert.Nil(t, duration)
+		assert.ErrorContains(t, err, "min cannot be less than or equal to zero")
+	})
+
+	t.Run("max cannot be below or equal to min", func(t *testing.T) {
+		duration, err := DurationInRange(100, 50)
+		assert.Nil(t, duration)
+		assert.ErrorContains(t, err, "max cannot be greater than or equal to zero")
+	})
+
+	t.Run("duration is in range", func(t *testing.T) {
+		duration, err := DurationInRange(50, 100)
+		assert.Nil(t, err)
+		assert.GreaterOrEqual(t, int(*duration/time.Millisecond), 50)
+		assert.LessOrEqual(t, int(*duration/time.Millisecond), 100)
+	})
+}


### PR DESCRIPTION
In #156, we started using a random delay for log requests. We should follow the same idea and also use a random delay for sync requests. The current delay for those requests is fixed at 5s. Here, we update it to a random delay between 3s - 6s.