### PR TITLE
fix: always include agent name in logs

### DIFF
--- a/pkg/eventlogger/formatter.go
+++ b/pkg/eventlogger/formatter.go
@@ -17,7 +17,7 @@ func (f *CustomFormatter) Format(entry *log.Entry) ([]byte, error) {
 	parts = append(parts, entry.Time.UTC().Format(time.StampMilli))
 
 	if f.AgentName != "" {
-		parts = append(parts, fmt.Sprintf("agent_name=%s", f.AgentName))
+		parts = append(parts, f.AgentName)
 	}
 
 	extraFields := f.formatFields(entry.Data)

--- a/pkg/eventlogger/formatter.go
+++ b/pkg/eventlogger/formatter.go
@@ -13,27 +13,21 @@ type CustomFormatter struct {
 }
 
 func (f *CustomFormatter) Format(entry *log.Entry) ([]byte, error) {
-	extraFields := f.formatFields(entry.Data)
-	if extraFields == "" {
-		log := fmt.Sprintf(
-			"%s agent_name=%s : %s\n",
-			entry.Time.UTC().Format(time.StampMilli),
-			f.AgentName,
-			entry.Message,
-		)
+	parts := []string{}
+	parts = append(parts, entry.Time.UTC().Format(time.StampMilli))
 
-		return []byte(log), nil
+	if f.AgentName != "" {
+		parts = append(parts, fmt.Sprintf("agent_name=%s", f.AgentName))
 	}
 
-	log := fmt.Sprintf(
-		"%s agent_name=%s %s : %s\n",
-		entry.Time.UTC().Format(time.StampMilli),
-		f.AgentName,
-		extraFields,
-		entry.Message,
-	)
+	extraFields := f.formatFields(entry.Data)
+	if extraFields != "" {
+		parts = append(parts, extraFields)
+	}
 
-	return []byte(log), nil
+	parts = append(parts, ":")
+	parts = append(parts, fmt.Sprintf("%s\n", entry.Message))
+	return []byte(strings.Join(parts, " ")), nil
 }
 
 func (f *CustomFormatter) formatFields(fields log.Fields) string {

--- a/pkg/eventlogger/formatter.go
+++ b/pkg/eventlogger/formatter.go
@@ -2,15 +2,45 @@ package eventlogger
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	log "github.com/sirupsen/logrus"
 )
 
 type CustomFormatter struct {
+	AgentName string
 }
 
 func (f *CustomFormatter) Format(entry *log.Entry) ([]byte, error) {
-	log := fmt.Sprintf("%-20s: %s\n", entry.Time.UTC().Format(time.StampMilli), entry.Message)
+	extraFields := f.formatFields(entry.Data)
+	if extraFields == "" {
+		log := fmt.Sprintf(
+			"%s agent_name=%s : %s\n",
+			entry.Time.UTC().Format(time.StampMilli),
+			f.AgentName,
+			entry.Message,
+		)
+
+		return []byte(log), nil
+	}
+
+	log := fmt.Sprintf(
+		"%s agent_name=%s %s : %s\n",
+		entry.Time.UTC().Format(time.StampMilli),
+		f.AgentName,
+		extraFields,
+		entry.Message,
+	)
+
 	return []byte(log), nil
+}
+
+func (f *CustomFormatter) formatFields(fields log.Fields) string {
+	result := []string{}
+	for key, value := range fields {
+		result = append(result, fmt.Sprintf("%s=%s", key, value))
+	}
+
+	return strings.Join(result, " ")
 }

--- a/pkg/listener/listener.go
+++ b/pkg/listener/listener.go
@@ -1,8 +1,6 @@
 package listener
 
 import (
-	"crypto/rand"
-	"encoding/base64"
 	"fmt"
 	"net/http"
 	"os"
@@ -38,6 +36,7 @@ type Config struct {
 	FailOnPreJobHookError      bool
 	ExitOnShutdown             bool
 	AgentVersion               string
+	AgentName                  string
 }
 
 func Start(httpClient *http.Client, config Config) (*Listener, error) {
@@ -50,7 +49,7 @@ func Start(httpClient *http.Client, config Config) (*Listener, error) {
 
 	log.Info("Starting Agent")
 	log.Info("Registering Agent")
-	err := listener.Register()
+	err := listener.Register(config.AgentName)
 	if err != nil {
 		return listener, err
 	}
@@ -87,27 +86,7 @@ func (l *Listener) DisplayHelloMessage() {
 	fmt.Println("                                      ")
 }
 
-// base64 gives you 4 chars every 3 bytes, we want 20 chars, so 15 bytes
-const nameLength = 15
-
-func (l *Listener) Name() (string, error) {
-	buffer := make([]byte, nameLength)
-	_, err := rand.Read(buffer)
-
-	if err != nil {
-		return "", err
-	}
-
-	return base64.URLEncoding.EncodeToString(buffer), nil
-}
-
-func (l *Listener) Register() error {
-	name, err := l.Name()
-	if err != nil {
-		log.Errorf("Error generating name for agent: %v", err)
-		return err
-	}
-
+func (l *Listener) Register(name string) error {
 	req := &selfhostedapi.RegisterRequest{
 		Version:     l.Config.AgentVersion,
 		Name:        name,
@@ -119,7 +98,7 @@ func (l *Listener) Register() error {
 		IdleTimeout: l.Config.DisconnectAfterIdleSeconds,
 	}
 
-	err = retry.RetryWithConstantWait(retry.RetryOptions{
+	err := retry.RetryWithConstantWait(retry.RetryOptions{
 		Task:                 "Register",
 		MaxAttempts:          l.Config.RegisterRetryLimit,
 		DelayBetweenAttempts: time.Second,

--- a/pkg/listener/listener_test.go
+++ b/pkg/listener/listener_test.go
@@ -3,6 +3,7 @@ package listener
 import (
 	"fmt"
 	"io/ioutil"
+	"math/rand"
 	"net/http"
 	"os"
 	"strings"
@@ -28,6 +29,7 @@ func Test__Register(t *testing.T) {
 	hubMockServer.UseLogsURL(loghubMockServer.URL())
 
 	config := Config{
+		AgentName:          fmt.Sprintf("agent-name-%d", rand.Intn(10000000)),
 		ExitOnShutdown:     false,
 		Endpoint:           hubMockServer.Host(),
 		Token:              "token",
@@ -68,6 +70,7 @@ func Test__RegisterRequestIsRetried(t *testing.T) {
 	hubMockServer.RejectRegisterAttempts(3)
 
 	config := Config{
+		AgentName:          fmt.Sprintf("agent-name-%d", rand.Intn(10000000)),
 		ExitOnShutdown:     false,
 		Endpoint:           hubMockServer.Host(),
 		Token:              "token",
@@ -109,6 +112,7 @@ func Test__RegistrationFails(t *testing.T) {
 	hubMockServer.RejectRegisterAttempts(10)
 
 	config := Config{
+		AgentName:          fmt.Sprintf("agent-name-%d", rand.Intn(10000000)),
 		ExitOnShutdown:     false,
 		Endpoint:           hubMockServer.Host(),
 		Token:              "token",
@@ -151,6 +155,7 @@ func Test__ShutdownHookIsExecuted(t *testing.T) {
 	assert.Nil(t, err)
 
 	config := Config{
+		AgentName:          fmt.Sprintf("agent-name-%d", rand.Intn(10000000)),
 		ExitOnShutdown:     false,
 		Endpoint:           hubMockServer.Host(),
 		Token:              "token",
@@ -202,6 +207,7 @@ func Test__ShutdownHookCanSeeShutdownReason(t *testing.T) {
 	assert.Nil(t, err)
 
 	config := Config{
+		AgentName:          fmt.Sprintf("agent-name-%d", rand.Intn(10000000)),
 		ExitOnShutdown:     false,
 		Endpoint:           hubMockServer.Host(),
 		Token:              "token",
@@ -246,6 +252,7 @@ func Test__ShutdownAfterJobFinished(t *testing.T) {
 	hubMockServer.UseLogsURL(loghubMockServer.URL())
 
 	config := Config{
+		AgentName:          fmt.Sprintf("agent-name-%d", rand.Intn(10000000)),
 		ExitOnShutdown:     false,
 		DisconnectAfterJob: true,
 		Endpoint:           hubMockServer.Host(),
@@ -294,6 +301,7 @@ func Test__ShutdownAfterIdleTimeout(t *testing.T) {
 	hubMockServer.UseLogsURL(loghubMockServer.URL())
 
 	config := Config{
+		AgentName:                  fmt.Sprintf("agent-name-%d", rand.Intn(10000000)),
 		ExitOnShutdown:             false,
 		DisconnectAfterIdleSeconds: 15,
 		Endpoint:                   hubMockServer.Host(),
@@ -325,6 +333,7 @@ func Test__ShutdownFromUpstreamWhileWaiting(t *testing.T) {
 	hubMockServer.UseLogsURL(loghubMockServer.URL())
 
 	config := Config{
+		AgentName:          fmt.Sprintf("agent-name-%d", rand.Intn(10000000)),
 		ExitOnShutdown:     false,
 		Endpoint:           hubMockServer.Host(),
 		Token:              "token",
@@ -359,6 +368,7 @@ func Test__ShutdownFromUpstreamWhileRunningJob(t *testing.T) {
 	hubMockServer.UseLogsURL(loghubMockServer.URL())
 
 	config := Config{
+		AgentName:          fmt.Sprintf("agent-name-%d", rand.Intn(10000000)),
 		ExitOnShutdown:     false,
 		Endpoint:           hubMockServer.Host(),
 		Token:              "token",
@@ -409,6 +419,7 @@ func Test__HostEnvVarsAreExposedToJob(t *testing.T) {
 	hubMockServer.UseLogsURL(loghubMockServer.URL())
 
 	config := Config{
+		AgentName:          fmt.Sprintf("agent-name-%d", rand.Intn(10000000)),
 		ExitOnShutdown:     false,
 		Endpoint:           hubMockServer.Host(),
 		Token:              "token",
@@ -543,6 +554,7 @@ func Test__LogTokenIsRefreshed(t *testing.T) {
 	hubMockServer.UseLogsURL(loghubMockServer.URL())
 
 	config := Config{
+		AgentName:          fmt.Sprintf("agent-name-%d", rand.Intn(10000000)),
 		ExitOnShutdown:     false,
 		Endpoint:           hubMockServer.Host(),
 		Token:              "token",
@@ -619,6 +631,7 @@ func Test__GetJobIsRetried(t *testing.T) {
 	hubMockServer.RejectGetJobAttempts(5)
 
 	config := Config{
+		AgentName:          fmt.Sprintf("agent-name-%d", rand.Intn(10000000)),
 		DisconnectAfterJob: true,
 		ExitOnShutdown:     false,
 		Endpoint:           hubMockServer.Host(),
@@ -670,6 +683,7 @@ func Test__ReportsFailedToFetchJob(t *testing.T) {
 	hubMockServer.RejectGetJobAttempts(100)
 
 	config := Config{
+		AgentName:          fmt.Sprintf("agent-name-%d", rand.Intn(10000000)),
 		DisconnectAfterJob: false,
 		ExitOnShutdown:     false,
 		Endpoint:           hubMockServer.Host(),
@@ -718,6 +732,7 @@ func Test__ReportsFailedToConstructJob(t *testing.T) {
 	hubMockServer.UseLogsURL(loghubMockServer.URL())
 
 	config := Config{
+		AgentName:          fmt.Sprintf("agent-name-%d", rand.Intn(10000000)),
 		DisconnectAfterJob: false,
 		ExitOnShutdown:     false,
 		Endpoint:           hubMockServer.Host(),


### PR DESCRIPTION
If you have multiple agents running in AWS, with all their logs being streamed to CloudWatch, it's not easy to find an agent's logs by their name. This makes it possible:
- Adds the agent name in all the logs (for self-hosted, since hosted agents have no name, their logs will not change).
- Adds any extra fields that may be added to the logs as well.

This is what the logs for self-hosted agents will look like now:

```
Aug 11 21:07:26.242 b8-usBzORGs32cdhXlE8 : Starting to poll for jobs
Aug 11 21:07:26.243 b8-usBzORGs32cdhXlE8 : SYNC request (state: waiting-for-jobs)
Aug 11 21:07:26.243 b8-usBzORGs32cdhXlE8 : SYNC response (action: continue)
Aug 11 21:07:26.243 b8-usBzORGs32cdhXlE8 : Waiting 3.764s for next sync...
Aug 11 21:07:30.010 b8-usBzORGs32cdhXlE8 : SYNC request (state: waiting-for-jobs)
Aug 11 21:07:30.011 b8-usBzORGs32cdhXlE8 : SYNC response (action: run-job, job: 59bbedba-9285-4f6b-9154-a6b2f3a18909)
Aug 11 21:07:30.011 b8-usBzORGs32cdhXlE8 : Waiting 3.197s for next sync...
```

In case extra fields are added to a message (with `log.WithFields(...).Info(...)`), this is what it looks like:

```
Aug 11 21:19:34.359 9EL1YIENglPv_Ybkf5pm : Starting Agent
Aug 11 21:19:34.360 9EL1YIENglPv_Ybkf5pm : Registering Agent
Aug 11 21:19:34.655 9EL1YIENglPv_Ybkf5pm : Starting to poll for jobs
Aug 11 21:19:34.656 9EL1YIENglPv_Ybkf5pm : SYNC request (state: waiting-for-jobs)
Aug 11 21:19:34.833 9EL1YIENglPv_Ybkf5pm : SYNC response (action: continue)
Aug 11 21:19:34.834 9EL1YIENglPv_Ybkf5pm extraField1=specialValue1 extraField2=specialValue2 : Waiting 3.106s for next sync...
Aug 11 21:19:37.943 9EL1YIENglPv_Ybkf5pm : SYNC request (state: waiting-for-jobs)
Aug 11 21:19:38.110 9EL1YIENglPv_Ybkf5pm : SYNC response (action: continue)
```