### PR TITLE
feat: set `--registry-ids` if `AWS_ACCOUNT_ID` is specified

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ require (
 	github.com/golang-jwt/jwt/v4 v4.4.2
 	github.com/gorilla/handlers v1.5.1
 	github.com/gorilla/mux v1.8.0
+	github.com/hashicorp/go-version v1.6.0
 	github.com/mitchellh/panicwrap v1.0.0
 	github.com/renderedtext/go-watchman v0.0.0-20220524201126-042727917d44
 	github.com/sirupsen/logrus v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -127,6 +127,8 @@ github.com/gorilla/handlers v1.5.1 h1:9lRY6j8DEeeBT10CvO9hGW0gmky0BprnvDI5vfhUHH
 github.com/gorilla/handlers v1.5.1/go.mod h1:t8XrUpc4KVXb7HGyJ4/cEnwQiaxrX/hz1Zv/4g96P1Q=
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
+github.com/hashicorp/go-version v1.6.0 h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mOkIeek=
+github.com/hashicorp/go-version v1.6.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=

--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -1,0 +1,77 @@
+package aws
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+
+	versions "github.com/hashicorp/go-version"
+	log "github.com/sirupsen/logrus"
+)
+
+func GetECRLoginCmd() (string, error) {
+	version, _ := versions.NewVersion("1.17.10")
+	awsCLIVersion, err := findAWSCLIVersion()
+	if err != nil {
+		return "", err
+	}
+
+	if awsCLIVersion.GreaterThanOrEqual(version) {
+		/*
+		 * get-login-password was added in v1.17.10 and is the only command available in v2.
+		 * That command doesn't generate a docker login command by itself, only the password.
+		 * So we need to pipe that into the docker login command ourselves.
+		 * See: https://docs.aws.amazon.com/cli/latest/reference/ecr/get-login-password.html.
+		 * The only difference here is that we need to determine the AWS account id for ourselves.
+		 */
+		accountId, err := findAWSAccountId()
+		if err != nil {
+			return "", err
+		}
+
+		return fmt.Sprintf(
+			`aws ecr get-login-password --region $AWS_REGION | docker login --username AWS --password-stdin %s.dkr.ecr.$AWS_REGION.amazonaws.com`,
+			accountId,
+		), nil
+	}
+
+	/*
+	 * get-login is only available in AWS CLI v1.
+	 * The way it works is it generates a token, and then prints the
+	 * docker login command to actually login. Note the extra $() around it.
+	 * This is to make sure we execute the output of that command as well.
+	 * See: https://docs.aws.amazon.com/cli/latest/reference/ecr/get-login.html
+	 */
+	return `$(aws ecr get-login --no-include-email --region $AWS_REGION)`, nil
+}
+
+func findAWSAccountId() (string, error) {
+	cmd := exec.Command("bash", "-c", "aws sts get-caller-identity --query Account --output text")
+	output, err := cmd.CombinedOutput()
+
+	if err != nil {
+		log.Errorf("Error finding AWS account ID: %v", err)
+		return "", err
+	}
+
+	return strings.TrimSuffix(string(output), "\n"), nil
+}
+
+func findAWSCLIVersion() (*versions.Version, error) {
+	cmd := exec.Command("bash", "-c", `aws --version 2>&1 | awk -F'[/ ]' '{print $2}'`)
+	output, err := cmd.CombinedOutput()
+
+	if err != nil {
+		log.Errorf("Error determing AWS CLI version: %v", err)
+		return nil, err
+	}
+
+	versionAsString := strings.TrimSuffix(string(output), "\n")
+	version, err := versions.NewVersion(versionAsString)
+	if err != nil {
+		log.Errorf("Error parsing AWS CLI version from '%s': %v", versionAsString, err)
+		return nil, err
+	}
+
+	return version, nil
+}

--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -52,7 +52,7 @@ func findAWSAccountID(envs []string) (string, error) {
 
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		log.Errorf("Error finding AWS account ID: %v", err)
+		log.Errorf("Error finding AWS account ID: Output: %s - Error: %v", string(output), err)
 		return "", err
 	}
 
@@ -62,9 +62,8 @@ func findAWSAccountID(envs []string) (string, error) {
 func findAWSCLIVersion() (*versions.Version, error) {
 	cmd := exec.Command("bash", "-c", `aws --version 2>&1 | awk -F'[/ ]' '{print $2}'`)
 	output, err := cmd.CombinedOutput()
-
 	if err != nil {
-		log.Errorf("Error determing AWS CLI version: %v", err)
+		log.Errorf("Error determing AWS CLI version: Output '%s' - Error: %v", string(output), err)
 		return nil, err
 	}
 

--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -17,9 +17,9 @@ func GetECRLoginCmd(envs []string) (string, error) {
 	}
 
 	if awsCLIVersion.GreaterThanOrEqual(awsV2) {
-		accountID := getAWSAccountIDFromVars(envs)
+		accountID := getAccountIDFromVars(envs)
 		if accountID == "" {
-			accountID, err = getAWSAccountIDFromSTS(envs)
+			accountID, err = getAccountIDFromSTS(envs)
 			if err != nil {
 				return "", err
 			}
@@ -45,7 +45,7 @@ func GetECRLoginCmd(envs []string) (string, error) {
 	 * This is to make sure we execute the output of that command as well.
 	 * See: https://docs.aws.amazon.com/cli/latest/reference/ecr/get-login.html
 	 */
-	accountID := getAWSAccountIDFromVars(envs)
+	accountID := getAccountIDFromVars(envs)
 	if accountID == "" {
 		return `$(aws ecr get-login --no-include-email --region $AWS_REGION)`, nil
 	}
@@ -57,7 +57,7 @@ func GetECRLoginCmd(envs []string) (string, error) {
 	return fmt.Sprintf(`$(aws ecr get-login --no-include-email --region $AWS_REGION --registry-ids %s)`, accountID), nil
 }
 
-func getAWSAccountIDFromVars(envs []string) string {
+func getAccountIDFromVars(envs []string) string {
 	for _, envVar := range envs {
 		parts := strings.Split(envVar, "=")
 		if parts[0] == "AWS_ACCOUNT_ID" {
@@ -68,7 +68,7 @@ func getAWSAccountIDFromVars(envs []string) string {
 	return ""
 }
 
-func getAWSAccountIDFromSTS(envs []string) (string, error) {
+func getAccountIDFromSTS(envs []string) (string, error) {
 	cmd := exec.Command("bash", "-c", "aws sts get-caller-identity --query Account --output text")
 	cmd.Env = envs
 

--- a/pkg/executors/docker_compose_executor.go
+++ b/pkg/executors/docker_compose_executor.go
@@ -12,9 +12,9 @@ import (
 	"strings"
 	"time"
 
-	versions "github.com/hashicorp/go-version"
 	watchman "github.com/renderedtext/go-watchman"
 	api "github.com/semaphoreci/agent/pkg/api"
+	aws "github.com/semaphoreci/agent/pkg/aws"
 	"github.com/semaphoreci/agent/pkg/config"
 	eventlogger "github.com/semaphoreci/agent/pkg/eventlogger"
 	shell "github.com/semaphoreci/agent/pkg/shell"
@@ -393,7 +393,11 @@ func (e *DockerComposeExecutor) injectImagePullSecretsForECR(envVars []api.EnvVa
 		envs = append(envs, fmt.Sprintf("%s=%s", name, string(value)))
 	}
 
-	loginCmd := e.getLoginCmd()
+	loginCmd, err := aws.GetECRLoginCmd()
+	if err != nil {
+		e.Logger.LogCommandOutput(fmt.Sprintf("Failed to determine docker login command: %v\n", err))
+		return 1
+	}
 
 	e.Logger.LogCommandOutput(loginCmd + "\n")
 
@@ -411,51 +415,6 @@ func (e *DockerComposeExecutor) injectImagePullSecretsForECR(envVars []api.EnvVa
 	}
 
 	return 0
-}
-
-func (e *DockerComposeExecutor) getLoginCmd() string {
-	version, _ := versions.NewVersion("v1.17.10")
-	awsCLIVersion := e.getAWSCLIVersion()
-
-	if awsCLIVersion.GreaterThanOrEqual(version) {
-		/*
-		 * get-login-password was added in v1.17.10 and is the only command available in v2.
-		 * That command doesn't generate a docker login command by itself, only the password.
-		 * So we need to pipe that into the docker login command ourselves.
-		 * See: https://docs.aws.amazon.com/cli/latest/reference/ecr/get-login-password.html.
-		 * TODO: do we need the docker registry URL at the end? Currently, we don't ask people to set the $AWS_ACCOUNT_ID variable in the secret.
-		 */
-		return `aws ecr get-login-password --region $AWS_REGION | docker login --username AWS --password-stdin $AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com`
-	}
-
-	/*
-	 * get-login is only available in AWS CLI v1.
-	 * The way it works is it generates a token, and then prints the
-	 * docker login command to actually login. Note the extra $() around it.
-	 * This is to make sure we execute the output of that command as well.
-	 * See: https://docs.aws.amazon.com/cli/latest/reference/ecr/get-login.html
-	 */
-	return `$(aws ecr get-login --no-include-email --region $AWS_REGION)`
-}
-
-// TODO: handle errors gracefully?
-func (e *DockerComposeExecutor) getAWSCLIVersion() *versions.Version {
-	getVersionCmd := `aws --version 2>&1 | awk -F'[/ ]' '{print $2}'`
-	cmd := exec.Command("bash", "-c", getVersionCmd)
-	output, err := cmd.CombinedOutput()
-
-	if err != nil {
-		log.Errorf("Error determing AWS CLI version: %v", err)
-		return nil
-	}
-
-	version, err := versions.NewVersion("v" + string(output))
-	if err != nil {
-		log.Errorf("Error determing AWS CLI version for '%s': %v", string(output), err)
-		return nil
-	}
-
-	return version
 }
 
 func (e *DockerComposeExecutor) injectImagePullSecretsForGCR(envVars []api.EnvVar, files []api.File) int {

--- a/pkg/executors/docker_compose_executor.go
+++ b/pkg/executors/docker_compose_executor.go
@@ -393,7 +393,7 @@ func (e *DockerComposeExecutor) injectImagePullSecretsForECR(envVars []api.EnvVa
 		envs = append(envs, fmt.Sprintf("%s=%s", name, string(value)))
 	}
 
-	loginCmd, err := aws.GetECRLoginCmd()
+	loginCmd, err := aws.GetECRLoginCmd(envs)
 	if err != nil {
 		e.Logger.LogCommandOutput(fmt.Sprintf("Failed to determine docker login command: %v\n", err))
 		return 1


### PR DESCRIPTION
This pull request fixes two issues when using an AWS ECR image to run jobs:
1. using the docker-compose executor with an AWS ECR image URL will not work if the AWS access credentials and the AWS ECR image live in separate AWS accounts. In order to fix that, we allow the `AWS_ACCOUNT_ID` to be specified and use that value to set the `--registry-ids` option for the `get-login` command.
2. using the docker-compose executor with an AWS ECR image URL will not work on a machine with the AWS CLI v2 installed. That's because the AWS CLI v2 no longer has the `get-login` command, which was replaced with the `get-login-password` command. 