### PR TITLE
fix: always use /tmp for SSH jump point

### DIFF
--- a/pkg/executors/shell_executor_test.go
+++ b/pkg/executors/shell_executor_test.go
@@ -40,7 +40,7 @@ func Test__ShellExecutor__SSHJumpPointIsNotCreatedForWindows(t *testing.T) {
 	sshJumpPointPath := "/tmp/ssh_jump_point"
 	os.Remove(sshJumpPointPath)
 	_, _ = setupShellExecutor(t, false)
-	assert.FileExists(t, sshJumpPointPath)
+	assert.NoFileExists(t, sshJumpPointPath)
 	os.Remove(sshJumpPointPath)
 }
 

--- a/pkg/executors/shell_executor_test.go
+++ b/pkg/executors/shell_executor_test.go
@@ -21,7 +21,23 @@ var UnicodeOutput1 = `特定の伝説に拠る物語の由来については諸�
 var UnicodeOutput2 = `━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━`
 
 func Test__ShellExecutor__SSHJumpPointIsCreatedForHosted(t *testing.T) {
-	sshJumpPointPath := filepath.Join(os.TempDir(), "ssh_jump_point")
+	if runtime.GOOS == "windows" {
+		t.Skip()
+	}
+
+	sshJumpPointPath := "/tmp/ssh_jump_point"
+	os.Remove(sshJumpPointPath)
+	_, _ = setupShellExecutor(t, false)
+	assert.FileExists(t, sshJumpPointPath)
+	os.Remove(sshJumpPointPath)
+}
+
+func Test__ShellExecutor__SSHJumpPointIsNotCreatedForWindows(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip()
+	}
+
+	sshJumpPointPath := "/tmp/ssh_jump_point"
 	os.Remove(sshJumpPointPath)
 	_, _ = setupShellExecutor(t, false)
 	assert.FileExists(t, sshJumpPointPath)
@@ -29,7 +45,7 @@ func Test__ShellExecutor__SSHJumpPointIsCreatedForHosted(t *testing.T) {
 }
 
 func Test__ShellExecutor__SSHJumpPointIsNotCreatedForSelfHosted(t *testing.T) {
-	sshJumpPointPath := filepath.Join(os.TempDir(), "ssh_jump_point")
+	sshJumpPointPath := "/tmp/ssh_jump_point"
 	os.Remove(sshJumpPointPath)
 	_, _ = setupShellExecutor(t, true)
 	assert.NoFileExists(t, sshJumpPointPath)

--- a/pkg/executors/ssh_jump_point.go
+++ b/pkg/executors/ssh_jump_point.go
@@ -2,11 +2,23 @@ package executors
 
 import (
 	"os"
-	"path/filepath"
+	"runtime"
+
+	log "github.com/sirupsen/logrus"
 )
 
 func SetUpSSHJumpPoint(script string) error {
-	path := filepath.Join(os.TempDir(), "ssh_jump_point")
+	if runtime.GOOS == "windows" {
+		log.Warn("Debug sessions are not supported in Windows - skipping")
+		return nil
+	}
+
+	/*
+	 * We can't use os.TempDir() here, because on macOS,
+	 * $TMPDIR resolves to something like /var/folders/rg/92ky7bj54xj6pcv5l24g6l_00000gn/T/,
+	 * and the sem CLI needs a /tmp/ssh_jump_point file.
+	 */
+	path := "/tmp/ssh_jump_point"
 
 	// #nosec
 	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE, 0644)


### PR DESCRIPTION
Agent v2.1.x introduced a regression that leads to debug sessions not working in our Mac cloud machines. The reason for that is that we started putting the ssh jump point in `$TMPDIR/ssh_jump_point`, but on Mac, `$TMPDIR` resolves to something like `/var/folders/qz/fys7r29s4cz9l_rn8zsmssz80000gn/T/`.

```
» sem debug job e9d74743-2c61-42ba-b4cf-620deb5b97ba
* Creating debug session for job 'e9d74743-2c61-42ba-b4cf-620deb5b97ba'
* Setting duration to 60 minutes
* Waiting for debug session to boot up .........
* Waiting for ssh daemon to become ready ....................

[ERROR] SSH connection can't be established; bash: /tmp/ssh_jump_point: No such file or directory; exit status 127

* Stopping debug session ..
* Session stopped
```