### PR TITLE
feat: allow name to be specified

### DIFF
--- a/main.go
+++ b/main.go
@@ -225,8 +225,8 @@ func validateConfiguration() {
 func getAgentName() string {
 	agentName := viper.GetString(config.Name)
 	if agentName != "" {
-		if len(agentName) > 64 {
-			log.Fatalf("The agent name can have up to 64 characters. '%s' has %d.", agentName, len(agentName))
+		if len(agentName) < 8 || len(agentName) > 64 {
+			log.Fatalf("The agent name should have between 8 and 64 characters. '%s' has %d.", agentName, len(agentName))
 		}
 
 		return agentName

--- a/main.go
+++ b/main.go
@@ -106,6 +106,7 @@ func getLogFilePath() string {
 
 func RunListener(httpClient *http.Client, logfile io.Writer) {
 	configFile := pflag.String(config.ConfigFile, "", "Config file")
+	_ = pflag.String(config.Name, "", "Name to use for the agent. If not set, a default random one is used.")
 	_ = pflag.String(config.Endpoint, "", "Endpoint where agents are registered")
 	_ = pflag.String(config.Token, "", "Registration token")
 	_ = pflag.Bool(config.NoHTTPS, false, "Use http for communication")
@@ -158,11 +159,7 @@ func RunListener(httpClient *http.Client, logfile io.Writer) {
 		log.Fatalf("Error parsing --files: %v", err)
 	}
 
-	agentName, err := randomName()
-	if err != nil {
-		log.Fatalf("Error generating name for agent: %v", err)
-	}
-
+	agentName := getAgentName()
 	formatter := eventlogger.CustomFormatter{AgentName: agentName}
 	log.SetFormatter(&formatter)
 
@@ -223,6 +220,25 @@ func validateConfiguration() {
 			log.Fatalf("Unrecognized option '%s'. Exiting...", key)
 		}
 	}
+}
+
+func getAgentName() string {
+	agentName := viper.GetString(config.Name)
+	if agentName != "" {
+		if len(agentName) > 64 {
+			log.Fatalf("The agent name can have up to 64 characters. '%s' has %d.", agentName, len(agentName))
+		}
+
+		return agentName
+	}
+
+	log.Infof("Agent name was not assigned - using a random one.")
+	randomName, err := randomName()
+	if err != nil {
+		log.Fatalf("Error generating name for agent: %v", err)
+	}
+
+	return randomName
 }
 
 func ParseEnvVars() ([]config.HostEnvVar, error) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -4,6 +4,7 @@ import "os"
 
 const (
 	ConfigFile                 = "config-file"
+	Name                       = "name"
 	Endpoint                   = "endpoint"
 	Token                      = "token"
 	NoHTTPS                    = "no-https"
@@ -19,6 +20,7 @@ const (
 
 var ValidConfigKeys = []string{
 	ConfigFile,
+	Name,
 	Endpoint,
 	Token,
 	NoHTTPS,


### PR DESCRIPTION
Currently, we only use random names for agents. But we should allow people to set the name they want for the agent they are registering. In order to support that, we add a new `--name` configuration parameter. If not set, we generate a random name. If set, we require the name to be between 8 and 64 characters.