### PR TITLE
fix: do not block output flushing on long empty TTY read

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/semaphoreci/agent
 
 require (
+	github.com/cenkalti/backoff v2.2.1+incompatible
+	github.com/cenkalti/backoff/v4 v4.1.3
 	github.com/creack/pty v1.1.18
 	github.com/golang-jwt/jwt/v4 v4.4.2
 	github.com/gorilla/handlers v1.5.1

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,6 @@
 module github.com/semaphoreci/agent
 
 require (
-	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/cenkalti/backoff/v4 v4.1.3
 	github.com/creack/pty v1.1.18
 	github.com/golang-jwt/jwt/v4 v4.4.2

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,10 @@ cloud.google.com/go/storage v1.14.0/go.mod h1:GrKmX003DSIwi9o29oFT7YDnHYwZoctc3f
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
+github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
+github.com/cenkalti/backoff/v4 v4.1.3 h1:cFAlzYUlVYDysBEH2T5hyJZMh3+5+WCBvSnK6Q8UtC4=
+github.com/cenkalti/backoff/v4 v4.1.3/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=

--- a/go.sum
+++ b/go.sum
@@ -38,8 +38,6 @@ cloud.google.com/go/storage v1.14.0/go.mod h1:GrKmX003DSIwi9o29oFT7YDnHYwZoctc3f
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
-github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/cenkalti/backoff/v4 v4.1.3 h1:cFAlzYUlVYDysBEH2T5hyJZMh3+5+WCBvSnK6Q8UtC4=
 github.com/cenkalti/backoff/v4 v4.1.3/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=

--- a/pkg/executors/docker_compose_executor.go
+++ b/pkg/executors/docker_compose_executor.go
@@ -714,7 +714,11 @@ func (e *DockerComposeExecutor) RunCommandWithOptions(options CommandOptions) in
 		directive = options.Alias
 	}
 
-	p := e.Shell.NewProcess(options.Command)
+	p := e.Shell.NewProcessWithOutput(options.Command, func(output string) {
+		if !options.Silent {
+			e.Logger.LogCommandOutput(output)
+		}
+	})
 
 	if !options.Silent {
 		e.Logger.LogCommandStarted(directive)
@@ -727,12 +731,6 @@ func (e *DockerComposeExecutor) RunCommandWithOptions(options CommandOptions) in
 			e.Logger.LogCommandOutput(fmt.Sprintf("Warning: %s\n", options.Warning))
 		}
 	}
-
-	p.OnStdout(func(output string) {
-		if !options.Silent {
-			e.Logger.LogCommandOutput(output)
-		}
-	})
 
 	p.Run()
 

--- a/pkg/executors/shell_executor.go
+++ b/pkg/executors/shell_executor.go
@@ -241,7 +241,11 @@ func (e *ShellExecutor) RunCommandWithOptions(options CommandOptions) int {
 		directive = options.Alias
 	}
 
-	p := e.Shell.NewProcess(options.Command)
+	p := e.Shell.NewProcessWithOutput(options.Command, func(output string) {
+		if !options.Silent {
+			e.Logger.LogCommandOutput(output)
+		}
+	})
 
 	if !options.Silent {
 		e.Logger.LogCommandStarted(directive)
@@ -254,12 +258,6 @@ func (e *ShellExecutor) RunCommandWithOptions(options CommandOptions) int {
 			e.Logger.LogCommandOutput(fmt.Sprintf("Warning: %s\n", options.Warning))
 		}
 	}
-
-	p.OnStdout(func(output string) {
-		if !options.Silent {
-			e.Logger.LogCommandOutput(output)
-		}
-	})
 
 	p.Run()
 

--- a/pkg/shell/output_buffer.go
+++ b/pkg/shell/output_buffer.go
@@ -143,7 +143,7 @@ func (b *OutputBuffer) flush() {
 	// indefinetily. We only run this check if the last insert was recent enough.
 	//
 
-	if b.timeSinceLastAppend() < OutputBufferMaxTimeSinceLastAppend {
+	if b.timeSinceLastAppend() < OutputBufferMaxTimeSinceLastAppend && !b.done {
 		for i := 0; i < 4; i++ {
 			if utf8.Valid(b.bytes[0:cutLength]) {
 				break

--- a/pkg/shell/output_buffer.go
+++ b/pkg/shell/output_buffer.go
@@ -153,6 +153,10 @@ func (b *OutputBuffer) flush() {
 		}
 	}
 
+	if cutLength == 0 {
+		return
+	}
+
 	bytes := make([]byte, cutLength)
 	copy(bytes, b.bytes[0:cutLength])
 	b.bytes = b.bytes[cutLength:]

--- a/pkg/shell/output_buffer_test.go
+++ b/pkg/shell/output_buffer_test.go
@@ -1,205 +1,205 @@
 package shell
 
-import (
-	"testing"
-	"time"
+// import (
+// 	"testing"
+// 	"time"
 
-	assert "github.com/stretchr/testify/assert"
-)
+// 	assert "github.com/stretchr/testify/assert"
+// )
 
-func Test__OutputBuffer__SimpleAscii(t *testing.T) {
-	buffer := NewOutputBuffer()
+// func Test__OutputBuffer__SimpleAscii(t *testing.T) {
+// 	buffer := NewOutputBuffer()
 
-	//
-	// Making sure that the input is long enough to the flushed immidiately
-	//
-	input := []byte{}
-	for i := 0; i < OutputBufferDefaultCutLength; i++ {
-		input = append(input, 'a')
-	}
+// 	//
+// 	// Making sure that the input is long enough to the flushed immediately
+// 	//
+// 	input := []byte{}
+// 	for i := 0; i < OutputBufferDefaultCutLength; i++ {
+// 		input = append(input, 'a')
+// 	}
 
-	buffer.Append(input)
-	flushed, ok := buffer.Flush()
+// 	buffer.Append(input)
+// 	flushed, ok := buffer.Flush()
 
-	assert.Equal(t, ok, true)
-	assert.Equal(t, flushed, string(input))
-}
+// 	assert.Equal(t, ok, true)
+// 	assert.Equal(t, flushed, string(input))
+// }
 
-func Test__OutputBuffer__SimpleAscii__ShorterThanMinimalCutLength(t *testing.T) {
-	buffer := NewOutputBuffer()
+// func Test__OutputBuffer__SimpleAscii__ShorterThanMinimalCutLength(t *testing.T) {
+// 	buffer := NewOutputBuffer()
 
-	input := []byte("aaa")
+// 	input := []byte("aaa")
 
-	buffer.Append(input)
-	_, ok := buffer.Flush()
+// 	buffer.Append(input)
+// 	_, ok := buffer.Flush()
 
-	// We need to wait a bit before flushing, the buffer is still too short
-	assert.Equal(t, ok, false)
+// 	// We need to wait a bit before flushing, the buffer is still too short
+// 	assert.Equal(t, ok, false)
 
-	time.Sleep(OutputBufferMaxTimeSinceLastAppend)
+// 	time.Sleep(OutputBufferMaxTimeSinceLastAppend)
 
-	flushed, ok := buffer.Flush()
-	assert.Equal(t, ok, true)
-	assert.Equal(t, flushed, string(input))
-}
+// 	flushed, ok := buffer.Flush()
+// 	assert.Equal(t, ok, true)
+// 	assert.Equal(t, flushed, string(input))
+// }
 
-func Test__OutputBuffer__SimpleAscii__LongerThanMinimalCutLength(t *testing.T) {
-	buffer := NewOutputBuffer()
+// func Test__OutputBuffer__SimpleAscii__LongerThanMinimalCutLength(t *testing.T) {
+// 	buffer := NewOutputBuffer()
 
-	//
-	// Making sure that the input is long enough to have to be flushed two times.
-	//
-	input := []byte{}
-	for i := 0; i < OutputBufferDefaultCutLength+50; i++ {
-		input = append(input, 'a')
-	}
+// 	//
+// 	// Making sure that the input is long enough to have to be flushed two times.
+// 	//
+// 	input := []byte{}
+// 	for i := 0; i < OutputBufferDefaultCutLength+50; i++ {
+// 		input = append(input, 'a')
+// 	}
 
-	buffer.Append(input)
+// 	buffer.Append(input)
 
-	flushed1, ok := buffer.Flush()
-	assert.Equal(t, ok, true)
-	assert.Equal(t, flushed1, string(input[:OutputBufferDefaultCutLength]))
+// 	flushed1, ok := buffer.Flush()
+// 	assert.Equal(t, ok, true)
+// 	assert.Equal(t, flushed1, string(input[:OutputBufferDefaultCutLength]))
 
-	// We need to wait a bit before flushing, the buffer is still too short
-	time.Sleep(OutputBufferMaxTimeSinceLastAppend)
+// 	// We need to wait a bit before flushing, the buffer is still too short
+// 	time.Sleep(OutputBufferMaxTimeSinceLastAppend)
 
-	flushed2, ok := buffer.Flush()
-	assert.Equal(t, ok, true)
-	assert.Equal(t, flushed2, string(input[OutputBufferDefaultCutLength:]))
-}
+// 	flushed2, ok := buffer.Flush()
+// 	assert.Equal(t, ok, true)
+// 	assert.Equal(t, flushed2, string(input[OutputBufferDefaultCutLength:]))
+// }
 
-func Test__OutputBuffer__UTF8_Sequence__Simple(t *testing.T) {
-	buffer := NewOutputBuffer()
+// func Test__OutputBuffer__UTF8_Sequence__Simple(t *testing.T) {
+// 	buffer := NewOutputBuffer()
 
-	//
-	// Making sure that the input is long enough to the flushed immidiately
-	//
-	input := []byte{}
-	for len(input) <= OutputBufferDefaultCutLength {
-		input = append(input, []byte("特")...)
-	}
+// 	//
+// 	// Making sure that the input is long enough to the flushed immidiately
+// 	//
+// 	input := []byte{}
+// 	for len(input) <= OutputBufferDefaultCutLength {
+// 		input = append(input, []byte("特")...)
+// 	}
 
-	buffer.Append(input)
+// 	buffer.Append(input)
 
-	out := ""
+// 	out := ""
 
-	for !buffer.IsEmpty() {
-		flushed, ok := buffer.Flush()
+// 	for !buffer.IsEmpty() {
+// 		flushed, ok := buffer.Flush()
 
-		if ok {
-			out += flushed
-		} else {
-			time.Sleep(OutputBufferMaxTimeSinceLastAppend)
-		}
-	}
+// 		if ok {
+// 			out += flushed
+// 		} else {
+// 			time.Sleep(OutputBufferMaxTimeSinceLastAppend)
+// 		}
+// 	}
 
-	assert.Equal(t, out, string(input))
-}
+// 	assert.Equal(t, out, string(input))
+// }
 
-func Test__OutputBuffer__UTF8_Sequence__Short(t *testing.T) {
-	buffer := NewOutputBuffer()
+// func Test__OutputBuffer__UTF8_Sequence__Short(t *testing.T) {
+// 	buffer := NewOutputBuffer()
 
-	//
-	// Making sure that the input is long enough to the flushed immidiately
-	//
-	input := []byte("特特特")
+// 	//
+// 	// Making sure that the input is long enough to the flushed immidiately
+// 	//
+// 	input := []byte("特特特")
 
-	buffer.Append(input)
+// 	buffer.Append(input)
 
-	out := ""
+// 	out := ""
 
-	for !buffer.IsEmpty() {
-		flushed, ok := buffer.Flush()
+// 	for !buffer.IsEmpty() {
+// 		flushed, ok := buffer.Flush()
 
-		if ok {
-			out += flushed
-		} else {
-			time.Sleep(OutputBufferMaxTimeSinceLastAppend)
-		}
-	}
+// 		if ok {
+// 			out += flushed
+// 		} else {
+// 			time.Sleep(OutputBufferMaxTimeSinceLastAppend)
+// 		}
+// 	}
 
-	assert.Equal(t, out, string(input))
-}
+// 	assert.Equal(t, out, string(input))
+// }
 
-func Test__OutputBuffer__InvalidUTF8_Sequence(t *testing.T) {
-	buffer := NewOutputBuffer()
+// func Test__OutputBuffer__InvalidUTF8_Sequence(t *testing.T) {
+// 	buffer := NewOutputBuffer()
 
-	//
-	// Making sure that the input is long enough to the flushed immidiately
-	//
-	input := []byte{}
-	for len(input) <= OutputBufferDefaultCutLength {
-		input = append(input, []byte("\xF4\xBF\xBF\xBF")...)
-	}
+// 	//
+// 	// Making sure that the input is long enough to the flushed immidiately
+// 	//
+// 	input := []byte{}
+// 	for len(input) <= OutputBufferDefaultCutLength {
+// 		input = append(input, []byte("\xF4\xBF\xBF\xBF")...)
+// 	}
 
-	buffer.Append(input)
+// 	buffer.Append(input)
 
-	out := ""
+// 	out := ""
 
-	for !buffer.IsEmpty() {
-		flushed, ok := buffer.Flush()
+// 	for !buffer.IsEmpty() {
+// 		flushed, ok := buffer.Flush()
 
-		if ok {
-			out += flushed
-		} else {
-			time.Sleep(OutputBufferMaxTimeSinceLastAppend)
-		}
-	}
+// 		if ok {
+// 			out += flushed
+// 		} else {
+// 			time.Sleep(OutputBufferMaxTimeSinceLastAppend)
+// 		}
+// 	}
 
-	assert.Equal(t, out, string(input))
-}
+// 	assert.Equal(t, out, string(input))
+// }
 
-func Test__OutputBuffer__FlushIgnoresCharactersThatAreNotUtf8Valid(t *testing.T) {
-	//
-	// We construct a 100 byte long string to enable a full flush.
-	//
-	// The first 99 bytes will come from the 3-byte long kanji character, while
-	// the last byte will be a broken character
+// func Test__OutputBuffer__FlushIgnoresCharactersThatAreNotUtf8Valid(t *testing.T) {
+// 	//
+// 	// We construct a 100 byte long string to enable a full flush.
+// 	//
+// 	// The first 99 bytes will come from the 3-byte long kanji character, while
+// 	// the last byte will be a broken character
 
-	buffer := NewOutputBuffer()
+// 	buffer := NewOutputBuffer()
 
-	input := ""
-	for i := 0; i < 33; i++ {
-		input += "特"
-	}
+// 	input := ""
+// 	for i := 0; i < 33; i++ {
+// 		input += "特"
+// 	}
 
-	nonUtf8Chars := []byte{[]byte("特")[0]}
+// 	nonUtf8Chars := []byte{[]byte("特")[0]}
 
-	// In total, we are inserting 100 bytes
-	buffer.Append([]byte(input))
-	buffer.Append(nonUtf8Chars)
+// 	// In total, we are inserting 100 bytes
+// 	buffer.Append([]byte(input))
+// 	buffer.Append(nonUtf8Chars)
 
-	// In the output, we expect that the last broken byte is not returned.
+// 	// In the output, we expect that the last broken byte is not returned.
 
-	out, ok := buffer.Flush()
+// 	out, ok := buffer.Flush()
 
-	assert.Equal(t, ok, true)
-	assert.Equal(t, out, input)
-}
+// 	assert.Equal(t, ok, true)
+// 	assert.Equal(t, out, input)
+// }
 
-func Test__OutputBuffer__FlushReturnsBytesThatAreBrokenAndSitInTheBufferForTooLong(t *testing.T) {
-	//
-	// We construct a 100 byte long string to enable a full flush.
-	//
-	// The first 99 bytes will come from the 3-byte long kanji character, while
-	// the last byte will be a broken character
-	//
+// func Test__OutputBuffer__FlushReturnsBytesThatAreBrokenAndSitInTheBufferForTooLong(t *testing.T) {
+// 	//
+// 	// We construct a 100 byte long string to enable a full flush.
+// 	//
+// 	// The first 99 bytes will come from the 3-byte long kanji character, while
+// 	// the last byte will be a broken character
+// 	//
 
-	buffer := NewOutputBuffer()
+// 	buffer := NewOutputBuffer()
 
-	input := []byte{}
-	for i := 0; i < 33; i++ {
-		input = append(input, []byte("特")...)
-	}
-	input = append(input, []byte("特")[0])
+// 	input := []byte{}
+// 	for i := 0; i < 33; i++ {
+// 		input = append(input, []byte("特")...)
+// 	}
+// 	input = append(input, []byte("特")[0])
 
-	buffer.Append(input)
+// 	buffer.Append(input)
 
-	// We wait for a while, and let the broken become bocome stale.
-	// Stale characters are forced out of the buffer, even if they are not valid.
-	time.Sleep(200 * time.Millisecond)
+// 	// We wait for a while, and let the broken become bocome stale.
+// 	// Stale characters are forced out of the buffer, even if they are not valid.
+// 	time.Sleep(200 * time.Millisecond)
 
-	out, ok := buffer.Flush()
-	assert.Equal(t, ok, true)
-	assert.Equal(t, out, string(input))
-}
+// 	out, ok := buffer.Flush()
+// 	assert.Equal(t, ok, true)
+// 	assert.Equal(t, out, string(input))
+// }

--- a/pkg/shell/output_buffer_test.go
+++ b/pkg/shell/output_buffer_test.go
@@ -40,12 +40,10 @@ func Test__OutputBuffer__SimpleAscii__ShorterThanMinimalCutLength(t *testing.T) 
 
 	// output is too short, so it will only be flushed
 	// when the max delay is reached.
-	time.Sleep(10 * time.Millisecond)
 	assert.Len(t, output, 0)
 
 	// We need to wait a bit before flushing, the buffer is still too short
-	time.Sleep(OutputBufferMaxTimeSinceLastAppend)
-	assert.Equal(t, strings.Join(output, ""), string(input))
+	assert.Eventually(t, func() bool { return strings.Join(output, "") == string(input) }, time.Second, 100*time.Millisecond)
 	buffer.Close()
 }
 

--- a/pkg/shell/output_buffer_test.go
+++ b/pkg/shell/output_buffer_test.go
@@ -8,6 +8,12 @@ import (
 	assert "github.com/stretchr/testify/assert"
 )
 
+func Test__OutputBuffer__RequiresConsumer(t *testing.T) {
+	buffer, err := NewOutputBuffer(nil)
+	assert.Error(t, err)
+	assert.Nil(t, buffer)
+}
+
 func Test__OutputBuffer__SimpleAscii(t *testing.T) {
 	output := []string{}
 	buffer, _ := NewOutputBuffer(func(s string) { output = append(output, s) })

--- a/pkg/shell/process.go
+++ b/pkg/shell/process.go
@@ -159,7 +159,6 @@ func (p *Process) Run() {
 	p.Shell.UpdateEnvironment(after)
 }
 
-// TODO: start output buffer flushing here
 func (p *Process) runWithoutPTY(instruction string) {
 	cmd, reader, writer := p.buildNonPTYCommand(instruction)
 	err := cmd.Start()
@@ -320,7 +319,6 @@ func (p *Process) writeCommandToFile(cmdFilePath, command string) error {
 	return file.Close()
 }
 
-// TODO: if we concurrently read what's in the output buffer, we probably don't need to worry about this.
 func (p *Process) readBufferSize() int {
 	if flag.Lookup("test.v") == nil {
 		return 100

--- a/pkg/shell/process.go
+++ b/pkg/shell/process.go
@@ -38,6 +38,7 @@ type Config struct {
 	Shell       *Shell
 	StoragePath string
 	Command     string
+	OnOutput    func(string)
 }
 
 type Process struct {
@@ -64,8 +65,8 @@ func randomMagicMark() string {
 func NewProcess(config Config) *Process {
 	startMark := randomMagicMark() + "-start"
 	endMark := randomMagicMark() + "-end"
-
 	commandEndRegex := regexp.MustCompile(endMark + " " + `(\d+)` + "[\r\n]+")
+	outputBuffer, _ := NewOutputBuffer(config.OnOutput)
 
 	return &Process{
 		Shell:           config.Shell,
@@ -75,7 +76,7 @@ func NewProcess(config Config) *Process {
 		startMark:       startMark,
 		endMark:         endMark,
 		commandEndRegex: commandEndRegex,
-		outputBuffer:    NewOutputBuffer(),
+		outputBuffer:    outputBuffer,
 	}
 }
 
@@ -89,29 +90,6 @@ func (p *Process) EnvironmentFilePath() string {
 
 func (p *Process) OnStdout(callback func(string)) {
 	p.OnStdoutCallback = callback
-}
-
-func (p *Process) StreamToStdout() {
-	for {
-		data, ok := p.outputBuffer.Flush()
-		if !ok {
-			break
-		}
-
-		log.Debugf("Stream to stdout: %#v", data)
-
-		p.OnStdoutCallback(data)
-	}
-}
-
-func (p *Process) flushOutputBuffer() {
-	for !p.outputBuffer.IsEmpty() {
-		p.StreamToStdout()
-
-		if !p.outputBuffer.IsEmpty() {
-			time.Sleep(10 * time.Millisecond)
-		}
-	}
 }
 
 func (p *Process) flushInputAll() {
@@ -186,6 +164,7 @@ func (p *Process) Run() {
 	p.Shell.UpdateEnvironment(after)
 }
 
+// TODO: start output buffer flushing here
 func (p *Process) runWithoutPTY(instruction string) {
 	cmd, reader, writer := p.buildNonPTYCommand(instruction)
 	err := cmd.Start()
@@ -346,6 +325,7 @@ func (p *Process) writeCommandToFile(cmdFilePath, command string) error {
 	return file.Close()
 }
 
+// TODO: if we concurrently read what's in the output buffer, we probably don't need to worry about this.
 func (p *Process) readBufferSize() int {
 	if flag.Lookup("test.v") == nil {
 		return 100
@@ -376,11 +356,10 @@ func (p *Process) readNonPTY(reader *io.PipeReader, done chan bool) {
 		p.inputBuffer = append(p.inputBuffer, buffer[0:n]...)
 		log.Debugf("reading data from command. Input buffer: %#v", string(p.inputBuffer))
 		p.flushInputAll()
-		p.StreamToStdout()
 
 		if err == io.EOF {
 			log.Debug("Finished reading")
-			p.flushOutputBuffer()
+			p.outputBuffer.Close()
 			break
 		}
 	}
@@ -487,21 +466,18 @@ func (p *Process) scan() error {
 			p.flushInputAll()
 		}
 
-		p.StreamToStdout()
-
 		err := p.read()
 		if err != nil {
 			// Reading failed. The most likely cause is that the bash process
 			// died. For example, running an `exit 1` command has killed it.
-
 			// Flushing all remaining data in the buffer and exiting.
-			p.flushOutputBuffer()
+			p.outputBuffer.Close()
 
 			return err
 		}
 	}
 
-	p.flushOutputBuffer()
+	p.outputBuffer.Close()
 
 	log.Debug("Command output finished")
 	log.Debugf("Parsing exit code %s", exitCode)

--- a/pkg/shell/process.go
+++ b/pkg/shell/process.go
@@ -42,20 +42,19 @@ type Config struct {
 }
 
 type Process struct {
-	Command          string
-	Shell            *Shell
-	StoragePath      string
-	StartedAt        int
-	FinishedAt       int
-	ExitCode         int
-	OnStdoutCallback func(string)
-	Pid              int
-	startMark        string
-	endMark          string
-	commandEndRegex  *regexp.Regexp
-	inputBuffer      []byte
-	outputBuffer     *OutputBuffer
-	SysProcAttr      *syscall.SysProcAttr
+	Command         string
+	Shell           *Shell
+	StoragePath     string
+	StartedAt       int
+	FinishedAt      int
+	ExitCode        int
+	Pid             int
+	startMark       string
+	endMark         string
+	commandEndRegex *regexp.Regexp
+	inputBuffer     []byte
+	outputBuffer    *OutputBuffer
+	SysProcAttr     *syscall.SysProcAttr
 }
 
 func randomMagicMark() string {
@@ -86,10 +85,6 @@ func (p *Process) CmdFilePath() string {
 
 func (p *Process) EnvironmentFilePath() string {
 	return fmt.Sprintf("%s.env.after", p.CmdFilePath())
-}
-
-func (p *Process) OnStdout(callback func(string)) {
-	p.OnStdoutCallback = callback
 }
 
 func (p *Process) flushInputAll() {

--- a/pkg/shell/shell.go
+++ b/pkg/shell/shell.go
@@ -224,6 +224,16 @@ func (s *Shell) NewProcess(command string) *Process {
 		})
 }
 
+func (s *Shell) NewProcessWithOutput(command string, onOutput func(string)) *Process {
+	return NewProcess(
+		Config{
+			Command:     command,
+			Shell:       s,
+			StoragePath: s.StoragePath,
+			OnOutput:    onOutput,
+		})
+}
+
 func (s *Shell) Close() error {
 	if s.TTY != nil {
 		err := s.TTY.Close()

--- a/pkg/shell/shell.go
+++ b/pkg/shell/shell.go
@@ -224,13 +224,13 @@ func (s *Shell) NewProcess(command string) *Process {
 		})
 }
 
-func (s *Shell) NewProcessWithOutput(command string, onOutput func(string)) *Process {
+func (s *Shell) NewProcessWithOutput(command string, outputConsumer func(string)) *Process {
 	return NewProcess(
 		Config{
 			Command:     command,
 			Shell:       s,
 			StoragePath: s.StoragePath,
-			OnOutput:    onOutput,
+			OnOutput:    outputConsumer,
 		})
 }
 

--- a/pkg/shell/shell_test.go
+++ b/pkg/shell/shell_test.go
@@ -49,12 +49,11 @@ func Test__Shell__SimpleHelloWorld(t *testing.T) {
 	shell, _ := NewShell(os.TempDir())
 	shell.Start()
 
-	p1 := shell.NewProcess("echo Hello")
-	p1.OnStdout(func(line string) {
+	p1 := shell.NewProcessWithOutput("echo Hello", func(line string) {
 		output.WriteString(line)
 	})
-	p1.Run()
 
+	p1.Run()
 	assert.Equal(t, output.String(), "Hello\n")
 }
 
@@ -76,12 +75,11 @@ func Test__Shell__HandlingBashProcessKill(t *testing.T) {
 		cmd = "echo Hello && exit 1"
 	}
 
-	p1 := shell.NewProcess(cmd)
-	p1.OnStdout(func(line string) {
+	p1 := shell.NewProcessWithOutput(cmd, func(line string) {
 		output.WriteString(line)
 	})
-	p1.Run()
 
+	p1.Run()
 	assert.Equal(t, output.String(), "Hello\n")
 }
 
@@ -106,16 +104,10 @@ func Test__Shell__HandlingBashProcessKillThatHasBackgroundJobs(t *testing.T) {
 	shell, _ := NewShell(os.TempDir())
 	shell.Start()
 
-	p1 := shell.NewProcess("sleep infinity &")
-	p1.OnStdout(func(line string) {
-		output.WriteString(line)
-	})
+	p1 := shell.NewProcessWithOutput("sleep infinity &", func(line string) { output.WriteString(line) })
 	p1.Run()
 
-	p2 := shell.NewProcess("echo 'Hello' && sleep 1 && exit 1")
-	p2.OnStdout(func(line string) {
-		output.WriteString(line)
-	})
+	p2 := shell.NewProcessWithOutput("echo 'Hello' && sleep 1 && exit 1", func(line string) { output.WriteString(line) })
 	p2.Run()
 
 	assert.Equal(t, output.String(), "Hello\n")


### PR DESCRIPTION
The current way the process' output buffer works is:
1. It reads some output from the TTY (blocking operation)
2. Appends the TTY output to the output buffer and attempts to flush. If the buffer is not in a good state for flushing (not enough data or not old-enough data), it returns to step 1 without flushing anything.

The issue with this implementation is that if the buffer was not flushed and has some output in it, and the next TTY read operation does not produce any output for a while, the output in the buffer will remain there until the TTY read in progress finishes. That can produce output that is misleading to the customers. See: https://github.com/semaphoreci/confluent/issues/75.

The way we fix this is by using a separate goroutine for the output buffer flushes, making sure that they are not blocked by any TTY read operations.

### Example jobs

- Without the fix: https://semaphore.semaphoreci.com/jobs/feaeb387-9bf0-4b31-a586-9be9d18bae2f#L45
- With the fix: https://semaphore.semaphoreci.com/jobs/00fc866a-a891-4234-b15d-4ad94e507b3f#L45