### PR TITLE
fix: increase output buffer flush timeout

### DIFF
--- a/pkg/eventlogger/httpbackend_test.go
+++ b/pkg/eventlogger/httpbackend_test.go
@@ -106,7 +106,7 @@ func Test__LogsArePushedToHTTPEndpoint(t *testing.T) {
 	eventObjects, err := TransformToObjects(mockServer.GetLogs())
 	assert.Nil(t, err)
 
-	simplifiedEvents, err := SimplifyLogEvents(eventObjects, true)
+	simplifiedEvents, err := SimplifyLogEvents(eventObjects, SimplifyOptions{IncludeOutput: true})
 	assert.Nil(t, err)
 
 	assert.Equal(t, []string{
@@ -148,7 +148,7 @@ func Test__RequestsAreCappedAtLinesPerRequest(t *testing.T) {
 	eventObjects, err := TransformToObjects(mockServer.GetLogs())
 	assert.Nil(t, err)
 
-	simplifiedEvents, err := SimplifyLogEvents(eventObjects, true)
+	simplifiedEvents, err := SimplifyLogEvents(eventObjects, SimplifyOptions{IncludeOutput: true})
 	assert.Nil(t, err)
 
 	assert.Equal(t, []string{
@@ -197,7 +197,7 @@ func Test__FlushingGivesUpAfterTimeout(t *testing.T) {
 	eventObjects, err := TransformToObjects(mockServer.GetLogs())
 	assert.Nil(t, err)
 
-	simplifiedEvents, err := SimplifyLogEvents(eventObjects, true)
+	simplifiedEvents, err := SimplifyLogEvents(eventObjects, SimplifyOptions{IncludeOutput: true})
 	assert.Nil(t, err)
 
 	// logs are incomplete
@@ -262,7 +262,7 @@ func Test__TokenIsRefreshed(t *testing.T) {
 	eventObjects, err := TransformToObjects(mockServer.GetLogs())
 	assert.Nil(t, err)
 
-	simplifiedEvents, err := SimplifyLogEvents(eventObjects, true)
+	simplifiedEvents, err := SimplifyLogEvents(eventObjects, SimplifyOptions{IncludeOutput: true})
 	assert.Nil(t, err)
 
 	assert.Equal(t, []string{

--- a/pkg/eventlogger/inmemorybackend.go
+++ b/pkg/eventlogger/inmemorybackend.go
@@ -35,12 +35,15 @@ func (l *InMemoryBackend) CloseWithOptions(options CloseOptions) error {
 	return nil
 }
 
-func (l *InMemoryBackend) SimplifiedEvents(includeOutput bool) ([]string, error) {
-	return SimplifyLogEvents(l.Events, includeOutput)
+func (l *InMemoryBackend) SimplifiedEvents(includeOutput, useSingleOutputEvent bool) ([]string, error) {
+	return SimplifyLogEvents(l.Events, SimplifyOptions{
+		IncludeOutput:          includeOutput,
+		UseSingleItemForOutput: useSingleOutputEvent,
+	})
 }
 
 func (l *InMemoryBackend) SimplifiedEventsWithoutDockerPull() ([]string, error) {
-	logs, err := l.SimplifiedEvents(true)
+	logs, err := l.SimplifiedEvents(true, false)
 	if err != nil {
 		return []string{}, err
 	}

--- a/pkg/eventlogger/test_helpers.go
+++ b/pkg/eventlogger/test_helpers.go
@@ -31,7 +31,12 @@ func TransformToObjects(events []string) ([]interface{}, error) {
 	return objects, nil
 }
 
-func SimplifyLogEvents(events []interface{}, includeOutput bool) ([]string, error) {
+type SimplifyOptions struct {
+	IncludeOutput          bool
+	UseSingleItemForOutput bool
+}
+
+func SimplifyLogEvents(events []interface{}, options SimplifyOptions) ([]string, error) {
 	simplified := []string{}
 
 	output := ""
@@ -45,9 +50,15 @@ func SimplifyLogEvents(events []interface{}, includeOutput bool) ([]string, erro
 		case *CommandStartedEvent:
 			simplified = append(simplified, "directive: "+e.Directive)
 		case *CommandOutputEvent:
-			output = output + e.Output
+			if options.IncludeOutput {
+				if options.UseSingleItemForOutput {
+					output = output + e.Output
+				} else {
+					simplified = append(simplified, e.Output)
+				}
+			}
 		case *CommandFinishedEvent:
-			if includeOutput {
+			if options.IncludeOutput && options.UseSingleItemForOutput {
 				if output != "" {
 					simplified = append(simplified, output)
 				}

--- a/pkg/eventlogger/test_helpers.go
+++ b/pkg/eventlogger/test_helpers.go
@@ -34,6 +34,8 @@ func TransformToObjects(events []string) ([]interface{}, error) {
 func SimplifyLogEvents(events []interface{}, includeOutput bool) ([]string, error) {
 	simplified := []string{}
 
+	output := ""
+
 	for _, event := range events {
 		switch e := event.(type) {
 		case *JobStartedEvent:
@@ -43,10 +45,16 @@ func SimplifyLogEvents(events []interface{}, includeOutput bool) ([]string, erro
 		case *CommandStartedEvent:
 			simplified = append(simplified, "directive: "+e.Directive)
 		case *CommandOutputEvent:
-			if includeOutput {
-				simplified = append(simplified, e.Output)
-			}
+			output = output + e.Output
 		case *CommandFinishedEvent:
+			if includeOutput {
+				if output != "" {
+					simplified = append(simplified, output)
+				}
+
+				output = ""
+			}
+
 			simplified = append(simplified, fmt.Sprintf("Exit Code: %d", e.ExitCode))
 		default:
 			return []string{}, fmt.Errorf("unknown shell event")

--- a/pkg/executors/shell_executor_test.go
+++ b/pkg/executors/shell_executor_test.go
@@ -83,12 +83,14 @@ func Test__ShellExecutor__EnvVars(t *testing.T) {
 
 	assert.Equal(t, simplifiedEvents, []string{
 		"directive: Exporting environment variables",
-		"Exporting A\n",
-		"Exporting B\n",
-		"Exporting C\n",
-		"Exporting D\n",
-		"Exporting VAR_WITH_ENV_VAR\n",
-		"Exporting VAR_WITH_QUOTES\n",
+		strings.Join([]string{
+			"Exporting A",
+			"Exporting B",
+			"Exporting C",
+			"Exporting D",
+			"Exporting VAR_WITH_ENV_VAR",
+			"Exporting VAR_WITH_QUOTES",
+		}, "\n") + "\n",
 		"Exit Code: 0",
 
 		fmt.Sprintf("directive: %s", testsupport.EchoEnvVar("A")),
@@ -175,11 +177,13 @@ func Test__ShellExecutor__InjectFiles(t *testing.T) {
 
 	assert.Equal(t, simplifiedEvents, []string{
 		"directive: Injecting Files",
-		fmt.Sprintf("Injecting %s with file mode 0400\n", absoluteFile.NormalizePath(homeDir)),
-		fmt.Sprintf("Injecting %s with file mode 0440\n", absoluteFileInMissingDir.NormalizePath(homeDir)),
-		fmt.Sprintf("Injecting %s with file mode 0600\n", relativeFile.NormalizePath(homeDir)),
-		fmt.Sprintf("Injecting %s with file mode 0644\n", relativeFileInMissingDir.NormalizePath(homeDir)),
-		fmt.Sprintf("Injecting %s with file mode 0777\n", homeFile.NormalizePath(homeDir)),
+		strings.Join([]string{
+			fmt.Sprintf("Injecting %s with file mode 0400", absoluteFile.NormalizePath(homeDir)),
+			fmt.Sprintf("Injecting %s with file mode 0440", absoluteFileInMissingDir.NormalizePath(homeDir)),
+			fmt.Sprintf("Injecting %s with file mode 0600", relativeFile.NormalizePath(homeDir)),
+			fmt.Sprintf("Injecting %s with file mode 0644", relativeFileInMissingDir.NormalizePath(homeDir)),
+			fmt.Sprintf("Injecting %s with file mode 0777", homeFile.NormalizePath(homeDir)),
+		}, "\n") + "\n",
 		"Exit Code: 0",
 
 		fmt.Sprintf("directive: %s", testsupport.Cat(absoluteFile.NormalizePath(homeDir))),
@@ -349,12 +353,7 @@ func Test__ShellExecutor__StoppingRunningJob(t *testing.T) {
 func Test__ShellExecutor__LargeCommandOutput(t *testing.T) {
 	e, testLoggerBackend := setupShellExecutor(t, true)
 
-	go func() {
-		assert.Zero(t, e.RunCommand(testsupport.LargeOutputCommand(), false, ""))
-	}()
-
-	time.Sleep(5 * time.Second)
-
+	assert.Zero(t, e.RunCommand(testsupport.LargeOutputCommand(), false, ""))
 	assert.Zero(t, e.Stop())
 	assert.Zero(t, e.Cleanup())
 

--- a/pkg/executors/shell_executor_test.go
+++ b/pkg/executors/shell_executor_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -364,11 +365,7 @@ func Test__ShellExecutor__LargeCommandOutput(t *testing.T) {
 
 	assert.Equal(t, simplifiedEvents, []string{
 		fmt.Sprintf("directive: %s", testsupport.LargeOutputCommand()),
-		"hellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohello",
-		"hellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohello",
-		"hellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohello",
-		"hellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohello",
-		"hellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohello",
+		strings.Repeat("hello", 100),
 		"Exit Code: 0",
 	})
 }
@@ -386,17 +383,11 @@ func Test__ShellExecutor__Unicode(t *testing.T) {
 
 	assert.Equal(t, simplifiedEvents, []string{
 		fmt.Sprintf("directive: %s", testsupport.Output(UnicodeOutput1)),
-		"特定の伝説に拠る物語の由来については諸説存在し。特定の伝説に拠る物",
-		"語の由来については諸説存在し。特定の伝説に拠る物語の由来については",
-		"諸説存在し。",
+		"特定の伝説に拠る物語の由来については諸説存在し。特定の伝説に拠る物語の由来については諸説存在し。特定の伝説に拠る物語の由来については諸説存在し。",
 		"Exit Code: 0",
 
 		fmt.Sprintf("directive: %s", testsupport.Output(UnicodeOutput2)),
-		"━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━",
-		"━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━",
-		"━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━",
-		"━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━",
-		"━━━━━━━━━━━━━━━━━━━━━━",
+		"━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━",
 		"Exit Code: 0",
 	})
 }

--- a/pkg/executors/shell_executor_test.go
+++ b/pkg/executors/shell_executor_test.go
@@ -78,19 +78,17 @@ func Test__ShellExecutor__EnvVars(t *testing.T) {
 	assert.Zero(t, e.Stop())
 	assert.Zero(t, e.Cleanup())
 
-	simplifiedEvents, err := testLoggerBackend.SimplifiedEvents(true)
+	simplifiedEvents, err := testLoggerBackend.SimplifiedEvents(true, false)
 	assert.Nil(t, err)
 
 	assert.Equal(t, simplifiedEvents, []string{
 		"directive: Exporting environment variables",
-		strings.Join([]string{
-			"Exporting A",
-			"Exporting B",
-			"Exporting C",
-			"Exporting D",
-			"Exporting VAR_WITH_ENV_VAR",
-			"Exporting VAR_WITH_QUOTES",
-		}, "\n") + "\n",
+		"Exporting A\n",
+		"Exporting B\n",
+		"Exporting C\n",
+		"Exporting D\n",
+		"Exporting VAR_WITH_ENV_VAR\n",
+		"Exporting VAR_WITH_QUOTES\n",
 		"Exit Code: 0",
 
 		fmt.Sprintf("directive: %s", testsupport.EchoEnvVar("A")),
@@ -172,18 +170,16 @@ func Test__ShellExecutor__InjectFiles(t *testing.T) {
 	assert.Zero(t, e.Stop())
 	assert.Zero(t, e.Cleanup())
 
-	simplifiedEvents, err := testLoggerBackend.SimplifiedEvents(true)
+	simplifiedEvents, err := testLoggerBackend.SimplifiedEvents(true, false)
 	assert.Nil(t, err)
 
 	assert.Equal(t, simplifiedEvents, []string{
 		"directive: Injecting Files",
-		strings.Join([]string{
-			fmt.Sprintf("Injecting %s with file mode 0400", absoluteFile.NormalizePath(homeDir)),
-			fmt.Sprintf("Injecting %s with file mode 0440", absoluteFileInMissingDir.NormalizePath(homeDir)),
-			fmt.Sprintf("Injecting %s with file mode 0600", relativeFile.NormalizePath(homeDir)),
-			fmt.Sprintf("Injecting %s with file mode 0644", relativeFileInMissingDir.NormalizePath(homeDir)),
-			fmt.Sprintf("Injecting %s with file mode 0777", homeFile.NormalizePath(homeDir)),
-		}, "\n") + "\n",
+		fmt.Sprintf("Injecting %s with file mode 0400\n", absoluteFile.NormalizePath(homeDir)),
+		fmt.Sprintf("Injecting %s with file mode 0440\n", absoluteFileInMissingDir.NormalizePath(homeDir)),
+		fmt.Sprintf("Injecting %s with file mode 0600\n", relativeFile.NormalizePath(homeDir)),
+		fmt.Sprintf("Injecting %s with file mode 0644\n", relativeFileInMissingDir.NormalizePath(homeDir)),
+		fmt.Sprintf("Injecting %s with file mode 0777\n", homeFile.NormalizePath(homeDir)),
 		"Exit Code: 0",
 
 		fmt.Sprintf("directive: %s", testsupport.Cat(absoluteFile.NormalizePath(homeDir))),
@@ -239,7 +235,7 @@ func Test__ShellExecutor__MultilineCommand(t *testing.T) {
 	assert.Zero(t, e.Stop())
 	assert.Zero(t, e.Cleanup())
 
-	simplifiedEvents, err := testLoggerBackend.SimplifiedEvents(true)
+	simplifiedEvents, err := testLoggerBackend.SimplifiedEvents(true, false)
 	assert.Nil(t, err)
 
 	assert.Equal(t, simplifiedEvents, []string{
@@ -274,7 +270,7 @@ func Test__ShellExecutor__ChangesCurrentDirectory(t *testing.T) {
 	assert.Zero(t, e.Stop())
 	assert.Zero(t, e.Cleanup())
 
-	simplifiedEvents, err := testLoggerBackend.SimplifiedEvents(false)
+	simplifiedEvents, err := testLoggerBackend.SimplifiedEvents(false, false)
 	assert.Nil(t, err)
 
 	assert.Equal(t, simplifiedEvents, []string{
@@ -304,7 +300,7 @@ func Test__ShellExecutor__ChangesEnvVars(t *testing.T) {
 	assert.Zero(t, e.Stop())
 	assert.Zero(t, e.Cleanup())
 
-	simplifiedEvents, err := testLoggerBackend.SimplifiedEvents(true)
+	simplifiedEvents, err := testLoggerBackend.SimplifiedEvents(true, false)
 	assert.Nil(t, err)
 
 	assert.Equal(t, simplifiedEvents, []string{
@@ -338,7 +334,7 @@ func Test__ShellExecutor__StoppingRunningJob(t *testing.T) {
 
 	time.Sleep(1 * time.Second)
 
-	simplifiedEvents, err := testLoggerBackend.SimplifiedEvents(true)
+	simplifiedEvents, err := testLoggerBackend.SimplifiedEvents(true, false)
 	assert.Nil(t, err)
 
 	assert.Equal(t, simplifiedEvents[0:4], []string{
@@ -359,7 +355,7 @@ func Test__ShellExecutor__LargeCommandOutput(t *testing.T) {
 
 	time.Sleep(1 * time.Second)
 
-	simplifiedEvents, err := testLoggerBackend.SimplifiedEvents(true)
+	simplifiedEvents, err := testLoggerBackend.SimplifiedEvents(true, true)
 	assert.Nil(t, err)
 
 	assert.Equal(t, simplifiedEvents, []string{
@@ -377,7 +373,7 @@ func Test__ShellExecutor__Unicode(t *testing.T) {
 	assert.Zero(t, e.Cleanup())
 
 	time.Sleep(1 * time.Second)
-	simplifiedEvents, err := testLoggerBackend.SimplifiedEvents(true)
+	simplifiedEvents, err := testLoggerBackend.SimplifiedEvents(true, true)
 	assert.Nil(t, err)
 
 	assert.Equal(t, simplifiedEvents, []string{
@@ -409,7 +405,7 @@ func Test__ShellExecutor__BrokenUnicode(t *testing.T) {
 
 	time.Sleep(1 * time.Second)
 
-	simplifiedEvents, err := testLoggerBackend.SimplifiedEvents(true)
+	simplifiedEvents, err := testLoggerBackend.SimplifiedEvents(true, false)
 	assert.Nil(t, err)
 
 	assert.Equal(t, simplifiedEvents, []string{

--- a/pkg/jobs/job_test.go
+++ b/pkg/jobs/job_test.go
@@ -133,8 +133,8 @@ func Test__EnvVarsAreAvailableToEpilogueAlwaysAndOnPass(t *testing.T) {
 		"job_started",
 
 		"directive: Exporting environment variables",
-		"Exporting A",
-		"Exporting B",
+		"Exporting A\n",
+		"Exporting B\n",
 		"Exit Code: 0",
 
 		"directive: Injecting Files",

--- a/pkg/jobs/job_test.go
+++ b/pkg/jobs/job_test.go
@@ -58,8 +58,10 @@ func Test__EnvVarsAreAvailableToCommands(t *testing.T) {
 		"job_started",
 
 		"directive: Exporting environment variables",
-		"Exporting A\n",
-		"Exporting B\n",
+		strings.Join([]string{
+			"Exporting A",
+			"Exporting B",
+		}, "\n") + "\n",
 		"Exit Code: 0",
 
 		"directive: Injecting Files",
@@ -133,8 +135,10 @@ func Test__EnvVarsAreAvailableToEpilogueAlwaysAndOnPass(t *testing.T) {
 		"job_started",
 
 		"directive: Exporting environment variables",
-		"Exporting A\n",
-		"Exporting B\n",
+		strings.Join([]string{
+			"Exporting A",
+			"Exporting B",
+		}, "\n") + "\n",
 		"Exit Code: 0",
 
 		"directive: Injecting Files",

--- a/pkg/jobs/job_test.go
+++ b/pkg/jobs/job_test.go
@@ -51,17 +51,15 @@ func Test__EnvVarsAreAvailableToCommands(t *testing.T) {
 	job.Run()
 	assert.True(t, job.Finished)
 
-	simplifiedEvents, err := testLoggerBackend.SimplifiedEvents(true)
+	simplifiedEvents, err := testLoggerBackend.SimplifiedEvents(true, false)
 	assert.Nil(t, err)
 
 	assert.Equal(t, simplifiedEvents, []string{
 		"job_started",
 
 		"directive: Exporting environment variables",
-		strings.Join([]string{
-			"Exporting A",
-			"Exporting B",
-		}, "\n") + "\n",
+		"Exporting A\n",
+		"Exporting B\n",
 		"Exit Code: 0",
 
 		"directive: Injecting Files",
@@ -128,17 +126,15 @@ func Test__EnvVarsAreAvailableToEpilogueAlwaysAndOnPass(t *testing.T) {
 	job.Run()
 	assert.True(t, job.Finished)
 
-	simplifiedEvents, err := testLoggerBackend.SimplifiedEvents(true)
+	simplifiedEvents, err := testLoggerBackend.SimplifiedEvents(true, false)
 	assert.Nil(t, err)
 
 	assert.Equal(t, simplifiedEvents, []string{
 		"job_started",
 
 		"directive: Exporting environment variables",
-		strings.Join([]string{
-			"Exporting A",
-			"Exporting B",
-		}, "\n") + "\n",
+		"Exporting A",
+		"Exporting B",
 		"Exit Code: 0",
 
 		"directive: Injecting Files",
@@ -234,7 +230,7 @@ func Test__EnvVarsAreAvailableToEpilogueAlwaysAndOnFail(t *testing.T) {
 	job.Run()
 	assert.True(t, job.Finished)
 
-	simplifiedEvents, err := testLoggerBackend.SimplifiedEvents(true)
+	simplifiedEvents, err := testLoggerBackend.SimplifiedEvents(true, false)
 	assert.Nil(t, err)
 
 	testsupport.AssertSimplifiedJobLogs(t, simplifiedEvents, []string{
@@ -334,7 +330,7 @@ func Test__EpilogueOnPassOnlyExecutesOnSuccessfulJob(t *testing.T) {
 	job.Run()
 	assert.True(t, job.Finished)
 
-	simplifiedEvents, err := testLoggerBackend.SimplifiedEvents(true)
+	simplifiedEvents, err := testLoggerBackend.SimplifiedEvents(true, false)
 	assert.Nil(t, err)
 
 	assert.Equal(t, simplifiedEvents, []string{
@@ -402,7 +398,7 @@ func Test__EpilogueOnFailOnlyExecutesOnFailedJob(t *testing.T) {
 	job.Run()
 	assert.True(t, job.Finished)
 
-	simplifiedEvents, err := testLoggerBackend.SimplifiedEvents(true)
+	simplifiedEvents, err := testLoggerBackend.SimplifiedEvents(true, false)
 	assert.Nil(t, err)
 
 	testsupport.AssertSimplifiedJobLogs(t, simplifiedEvents, []string{
@@ -461,7 +457,7 @@ func Test__UsingCommandAliases(t *testing.T) {
 	job.Run()
 	assert.True(t, job.Finished)
 
-	simplifiedEvents, err := testLoggerBackend.SimplifiedEvents(true)
+	simplifiedEvents, err := testLoggerBackend.SimplifiedEvents(true, false)
 	assert.Nil(t, err)
 
 	assert.Equal(t, simplifiedEvents, []string{
@@ -519,7 +515,7 @@ func Test__StopJob(t *testing.T) {
 	assert.True(t, job.Stopped)
 	assert.Eventually(t, func() bool { return job.Finished }, 5*time.Second, 1*time.Second)
 
-	simplifiedEvents, err := testLoggerBackend.SimplifiedEvents(true)
+	simplifiedEvents, err := testLoggerBackend.SimplifiedEvents(true, false)
 	assert.Nil(t, err)
 
 	assert.Equal(t, simplifiedEvents, []string{
@@ -573,7 +569,7 @@ func Test__StopJobOnEpilogue(t *testing.T) {
 	assert.True(t, job.Stopped)
 	assert.Eventually(t, func() bool { return job.Finished }, 5*time.Second, 1*time.Second)
 
-	simplifiedEvents, err := testLoggerBackend.SimplifiedEvents(true)
+	simplifiedEvents, err := testLoggerBackend.SimplifiedEvents(true, false)
 	assert.Nil(t, err)
 
 	assert.Equal(t, simplifiedEvents, []string{
@@ -627,7 +623,7 @@ func Test__STTYRestoration(t *testing.T) {
 	job.Run()
 	assert.True(t, job.Finished)
 
-	simplifiedEvents, err := testLoggerBackend.SimplifiedEvents(true)
+	simplifiedEvents, err := testLoggerBackend.SimplifiedEvents(true, false)
 	assert.Nil(t, err)
 
 	assert.Equal(t, simplifiedEvents, []string{
@@ -682,7 +678,7 @@ func Test__BackgroundJobIsKilledAfterJobIsDoneInWindows(t *testing.T) {
 	job.Run()
 	assert.True(t, job.Finished)
 
-	simplifiedEvents, err := testLoggerBackend.SimplifiedEvents(true)
+	simplifiedEvents, err := testLoggerBackend.SimplifiedEvents(true, false)
 	assert.Nil(t, err)
 
 	assert.Equal(t, simplifiedEvents, []string{
@@ -753,7 +749,7 @@ func Test__BackgroundJobIsKilledAfterJobIsDoneInNonWindows(t *testing.T) {
 	job.Run()
 	assert.True(t, job.Finished)
 
-	simplifiedEvents, err := testLoggerBackend.SimplifiedEvents(true)
+	simplifiedEvents, err := testLoggerBackend.SimplifiedEvents(true, false)
 	assert.Nil(t, err)
 
 	assert.Equal(t, simplifiedEvents, []string{
@@ -819,7 +815,7 @@ func Test__KillingRootBash(t *testing.T) {
 	job.Run()
 	assert.True(t, job.Finished)
 
-	simplifiedEvents, err := testLoggerBackend.SimplifiedEvents(true)
+	simplifiedEvents, err := testLoggerBackend.SimplifiedEvents(true, false)
 	assert.Nil(t, err)
 
 	assert.Equal(t, simplifiedEvents, []string{
@@ -873,7 +869,7 @@ func Test__BashSetE(t *testing.T) {
 	job.Run()
 	assert.True(t, job.Finished)
 
-	simplifiedEvents, err := testLoggerBackend.SimplifiedEvents(true)
+	simplifiedEvents, err := testLoggerBackend.SimplifiedEvents(true, false)
 	assert.Nil(t, err)
 
 	assert.Equal(t, simplifiedEvents, []string{
@@ -930,7 +926,7 @@ func Test__BashSetPipefail(t *testing.T) {
 	job.Run()
 	assert.True(t, job.Finished)
 
-	simplifiedEvents, err := testLoggerBackend.SimplifiedEvents(true)
+	simplifiedEvents, err := testLoggerBackend.SimplifiedEvents(true, false)
 	assert.Nil(t, err)
 
 	assert.Equal(t, simplifiedEvents, []string{
@@ -992,7 +988,7 @@ func Test__UsePreJobHook(t *testing.T) {
 
 	assert.True(t, job.Finished)
 
-	simplifiedEvents, err := testLoggerBackend.SimplifiedEvents(true)
+	simplifiedEvents, err := testLoggerBackend.SimplifiedEvents(true, false)
 	assert.Nil(t, err)
 
 	testsupport.AssertSimplifiedJobLogs(t, simplifiedEvents, []string{
@@ -1064,7 +1060,7 @@ func Test__PreJobHookHasAccessToEnvVars(t *testing.T) {
 
 	assert.True(t, job.Finished)
 
-	simplifiedEvents, err := testLoggerBackend.SimplifiedEvents(true)
+	simplifiedEvents, err := testLoggerBackend.SimplifiedEvents(true, false)
 	assert.Nil(t, err)
 
 	testsupport.AssertSimplifiedJobLogs(t, simplifiedEvents, []string{
@@ -1131,7 +1127,7 @@ func Test__UsePreJobHookAndFailOnError(t *testing.T) {
 
 	assert.True(t, job.Finished)
 
-	simplifiedEvents, err := testLoggerBackend.SimplifiedEvents(true)
+	simplifiedEvents, err := testLoggerBackend.SimplifiedEvents(true, false)
 	assert.Nil(t, err)
 
 	testsupport.AssertSimplifiedJobLogs(t, simplifiedEvents, []string{

--- a/pkg/listener/listener_test.go
+++ b/pkg/listener/listener_test.go
@@ -472,7 +472,7 @@ func Test__HostEnvVarsAreExposedToJob(t *testing.T) {
 	eventObjects, err := eventlogger.TransformToObjects(loghubMockServer.GetLogs())
 	assert.Nil(t, err)
 
-	simplifiedEvents, err := eventlogger.SimplifyLogEvents(eventObjects, true)
+	simplifiedEvents, err := eventlogger.SimplifyLogEvents(eventObjects, eventlogger.SimplifyOptions{IncludeOutput: true})
 	assert.Nil(t, err)
 
 	assert.Equal(t, []string{
@@ -591,7 +591,7 @@ func Test__LogTokenIsRefreshed(t *testing.T) {
 	eventObjects, err := eventlogger.TransformToObjects(loghubMockServer.GetLogs())
 	assert.Nil(t, err)
 
-	simplifiedEvents, err := eventlogger.SimplifyLogEvents(eventObjects, true)
+	simplifiedEvents, err := eventlogger.SimplifyLogEvents(eventObjects, eventlogger.SimplifyOptions{IncludeOutput: true})
 	assert.Nil(t, err)
 
 	assert.Equal(t, []string{

--- a/pkg/shell/output_buffer.go
+++ b/pkg/shell/output_buffer.go
@@ -209,11 +209,11 @@ func (b *OutputBuffer) timeSinceLastAppend() time.Duration {
 func (b *OutputBuffer) Close() {
 	b.done = true
 
-	// wait until buffer is empty, for at most 1s.
+	// wait until buffer is empty, for at most 5s.
 	log.Debugf("Waiting for buffer to be completely flushed...")
 	err := retry.RetryWithConstantWait(retry.RetryOptions{
 		Task:                 "wait for all output to be flushed",
-		MaxAttempts:          100,
+		MaxAttempts:          500,
 		DelayBetweenAttempts: 10 * time.Millisecond,
 		HideError:            true,
 		Fn: func() error {

--- a/pkg/shell/output_buffer.go
+++ b/pkg/shell/output_buffer.go
@@ -220,7 +220,7 @@ func (b *OutputBuffer) chunkSize() int {
 func (b *OutputBuffer) Close() {
 	b.done = true
 
-	// wait until buffer is empty, for at most 5s.
+	// wait until buffer is empty, for at most 10s.
 	log.Debugf("Waiting for buffer to be completely flushed...")
 	err := retry.RetryWithConstantWait(retry.RetryOptions{
 		Task:                 "wait for all output to be flushed",

--- a/pkg/shell/output_buffer.go
+++ b/pkg/shell/output_buffer.go
@@ -213,7 +213,7 @@ func (b *OutputBuffer) Close() {
 	log.Debugf("Waiting for buffer to be completely flushed...")
 	err := retry.RetryWithConstantWait(retry.RetryOptions{
 		Task:                 "wait for all output to be flushed",
-		MaxAttempts:          500,
+		MaxAttempts:          1000,
 		DelayBetweenAttempts: 10 * time.Millisecond,
 		HideError:            true,
 		Fn: func() error {

--- a/pkg/shell/output_buffer_test.go
+++ b/pkg/shell/output_buffer_test.go
@@ -61,10 +61,30 @@ func Test__OutputBuffer__SimpleAscii__LongerThanMinimalCutLength(t *testing.T) {
 
 	buffer.Append(input)
 
+	// wait for the output to be flushed
+	time.Sleep(time.Second)
+
 	buffer.Close()
 	if assert.Len(t, output, 2) {
 		assert.Equal(t, output[0], string(input[:OutputBufferDefaultCutLength]))
 		assert.Equal(t, output[1], string(input[OutputBufferDefaultCutLength:]))
+	}
+}
+
+func Test__OutputBuffer__SimpleAscii__ChunkIncreasesWhenClosed(t *testing.T) {
+	output := []string{}
+	buffer, _ := NewOutputBuffer(func(s string) { output = append(output, s) })
+	input := []byte{}
+	for i := 0; i < OutputBufferDefaultCutLength+50; i++ {
+		input = append(input, 'a')
+	}
+
+	buffer.Append(input)
+	buffer.Close()
+
+	// everything is flushed in one chunk
+	if assert.Len(t, output, 1) {
+		assert.Equal(t, output[0], string(input))
 	}
 }
 

--- a/test/e2e/docker/unicode.rb
+++ b/test/e2e/docker/unicode.rb
@@ -56,11 +56,7 @@ assert_job_log <<-LOG
   {"event":"cmd_started",  "timestamp":"*", "directive":"Injecting Files"}
   {"event":"cmd_finished", "timestamp":"*", "directive":"Injecting Files","exit_code":0,"finished_at":"*","started_at":"*"}
   {"event":"cmd_started",  "timestamp":"*", "directive":"echo 特定の伝説に拠る物語の由来については諸説存在し。特定の伝説に拠る物語の由来については諸説存在し。特定の伝説に拠る物語の由来については諸説存在し。"}
-
-  {"event":"cmd_output",   "timestamp":"*", "output":"特定の伝説に拠る物語の由来については諸説存在し。特定の伝説に拠る物"}
-  {"event":"cmd_output",   "timestamp":"*", "output":"語の由来については諸説存在し。特定の伝説に拠る物語の由来については"}
-  {"event":"cmd_output",   "timestamp":"*", "output":"諸説存在し。\\n"}
-
+  {"event":"cmd_output",   "timestamp":"*", "output":"特定の伝説に拠る物語の由来については諸説存在し。特定の伝説に拠る物語の由来については諸説存在し。特定の伝説に拠る物語の由来については諸説存在し。\\n"}
   {"event":"cmd_finished", "timestamp":"*", "directive":"echo 特定の伝説に拠る物語の由来については諸説存在し。特定の伝説に拠る物語の由来については諸説存在し。特定の伝説に拠る物語の由来については諸説存在し。","exit_code":0,"finished_at":"*","started_at":"*"}
   {"event":"cmd_started",  "timestamp":"*", "directive":"Exporting environment variables"}
   {"event":"cmd_output",   "timestamp":"*", "output":"Exporting SEMAPHORE_JOB_RESULT\\n"}


### PR DESCRIPTION
1s of timeout (at 10ms and 100 chunk size) can only flush 10k of data, which is not enough if the command generates a lot of output right at the end of it. If we increase the timeout to 10s and the chunk size to 1000 when the buffer is closed, we can flush 1M of data, which should be more than enough.

### Testing

Having a variable chunk size made a few tests start failing, so I had to adjust how we were asserting the outputs of commands in there.