### PR TITLE
fix: race condition on stop-job

### DIFF
--- a/test/hub_reference/Gemfile.lock
+++ b/test/hub_reference/Gemfile.lock
@@ -3,22 +3,22 @@ GEM
   specs:
     daemons (1.4.1)
     eventmachine (1.2.7)
-    mustermann (1.1.1)
+    mustermann (3.0.0)
       ruby2_keywords (~> 0.0.1)
-    rack (2.2.3.1)
-    rack-protection (2.2.0)
+    rack (2.2.4)
+    rack-protection (3.0.4)
       rack
     ruby2_keywords (0.0.5)
-    sinatra (2.2.0)
-      mustermann (~> 1.0)
-      rack (~> 2.2)
-      rack-protection (= 2.2.0)
+    sinatra (3.0.4)
+      mustermann (~> 3.0)
+      rack (~> 2.2, >= 2.2.4)
+      rack-protection (= 3.0.4)
       tilt (~> 2.0)
     thin (1.8.1)
       daemons (~> 1.0, >= 1.0.9)
       eventmachine (~> 1.0, >= 1.0.4)
       rack (>= 1, < 3)
-    tilt (2.0.10)
+    tilt (2.0.11)
 
 PLATFORMS
   ruby


### PR DESCRIPTION
Fixes a race condition that happens when a job finishes and is stopped around the same time:

```
API                                       Agent
 | <------------- running-job ------------- |
 |     job finishes (state=finished-job)    | <- job finished before the sync response was received, finished-job would be reported in the next sync request
 | --------------- stop-job --------------> | <- but the agent state is overwritten to stopping-job before that happens, and the agent gets stuck
```