### PR TITLE
fix: randomize size of TTY read buffer

### DIFF
--- a/pkg/shell/process.go
+++ b/pkg/shell/process.go
@@ -2,7 +2,6 @@ package shell
 
 import (
 	"encoding/base64"
-	"flag"
 	"fmt"
 	"io"
 	"math/rand"
@@ -348,18 +347,12 @@ func (p *Process) writeCommandToFile(cmdFilePath, command string) error {
 }
 
 func (p *Process) readBufferSize() int {
-	if flag.Lookup("test.v") == nil {
-		return 100
-	}
-
 	// simulating the worst kind of baud rate
-	// random in size, and possibly very short
-
-	// The implementation needs to handle everything.
+	// random in size, and possibly very short.
 	rand.Seed(time.Now().UnixNano())
 
-	min := 1
-	max := 20
+	min := 64
+	max := 256
 
 	// #nosec
 	return rand.Intn(max-min) + min
@@ -402,7 +395,7 @@ func (p *Process) read() error {
 	}
 
 	p.inputBuffer = append(p.inputBuffer, buffer[0:n]...)
-	log.Debugf("reading data from shell. Input buffer: %#v", string(p.inputBuffer))
+	log.Debugf("reading data (%d bytes) from shell. Input buffer: %#v", n, string(p.inputBuffer))
 
 	return nil
 }

--- a/pkg/shell/process_test.go
+++ b/pkg/shell/process_test.go
@@ -1,0 +1,67 @@
+package shell
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+)
+
+func Benchmark__CommandOutput_128Bytes(b *testing.B) {
+	p := createProcess(b, fmt.Sprintf("echo '%s'", strings.Repeat("x", 128)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		p.Run()
+	}
+}
+
+func Benchmark__CommandOutput_1K(b *testing.B) {
+	p := createProcess(b, fmt.Sprintf("echo '%s'", strings.Repeat("x", 1024)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		p.Run()
+	}
+}
+
+func Benchmark__CommandOutput_10K(b *testing.B) {
+	p := createProcess(b, fmt.Sprintf("for i in {0..10}; do echo '%s'; done", strings.Repeat("x", 1024)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		p.Run()
+	}
+}
+
+func Benchmark__CommandOutput_100K(b *testing.B) {
+	p := createProcess(b, fmt.Sprintf("for i in {0..100}; do echo '%s'; done", strings.Repeat("x", 1024)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		p.Run()
+	}
+}
+
+func Benchmark__CommandOutput_1M(b *testing.B) {
+	p := createProcess(b, fmt.Sprintf("for i in {0..1000}; do echo '%s'; done", strings.Repeat("x", 1024)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		p.Run()
+	}
+}
+
+func createProcess(b *testing.B, command string) *Process {
+	s, err := NewShell(os.TempDir())
+	if err != nil {
+		b.Fatalf("error creating shell: %v", err)
+	}
+
+	err = s.Start()
+	if err != nil {
+		b.Fatalf("error creating shell: %v", err)
+	}
+
+	return NewProcess(Config{
+		Shell:       s,
+		StoragePath: os.TempDir(),
+		Command:     command,
+		OnOutput:    func(string) { /* discard output */ },
+	})
+}


### PR DESCRIPTION
We are using a fixed-sized buffer for TTY reads of 100 bytes. Using a randomized-sized buffer seems to improve the execution of commands that generate a lot of output.

```
goos: darwin
goarch: amd64
pkg: github.com/semaphoreci/agent/pkg/shell
cpu: Intel(R) Core(TM) i7-6700HQ CPU @ 2.60GHz
                           │   100b.txt    │               64-256.txt               │
                           │    sec/op     │    sec/op     vs base                  │
__CommandOutput_128Bytes-8   122.6m ±   1%   122.7m ±  1%        ~ (p=0.579 n=10)
__CommandOutput_1K-8         133.2m ±   1%   134.2m ±  1%        ~ (p=0.089 n=10)
__CommandOutput_10K-8        135.1m ±   1%   136.6m ±  1%   +1.09% (p=0.023 n=10)
__CommandOutput_100K-8        1.129 ± 216%    1.331 ± 92%        ~ (p=0.105 n=10)
__CommandOutput_1M-8          68.38 ±  33%    24.66 ± 28%  -63.93% (p=0.000 n=9+10)
geomean                      701.9m          593.8m        -15.41%

                           │   100b.txt    │               64-256.txt                │
                           │     B/op      │     B/op       vs base                  │
__CommandOutput_128Bytes-8   17.95Ki ± 23%   14.13Ki ± 29%        ~ (p=0.796 n=10)
__CommandOutput_1K-8         26.30Ki ± 17%   27.65Ki ± 24%        ~ (p=0.631 n=10)
__CommandOutput_10K-8        171.3Ki ±  3%   157.6Ki ±  3%   -8.00% (p=0.000 n=10)
__CommandOutput_100K-8       1.534Mi ± 13%   1.261Mi ±  5%  -17.78% (p=0.000 n=10)
__CommandOutput_1M-8         12.06Mi ±  6%   11.76Mi ±  1%   -2.49% (p=0.000 n=9+10)
geomean                      274.9Ki         249.0Ki         -9.39%

                           │   100b.txt   │               64-256.txt               │
                           │  allocs/op   │  allocs/op    vs base                  │
__CommandOutput_128Bytes-8    104.5 ±  2%    102.0 ±  1%   -2.39% (p=0.005 n=10)
__CommandOutput_1K-8          221.0 ±  1%    177.5 ±  2%  -19.68% (p=0.000 n=10)
__CommandOutput_10K-8        1.496k ±  1%   1.000k ±  2%  -33.12% (p=0.000 n=10)
__CommandOutput_100K-8       12.58k ± 30%   10.94k ± 24%  -13.06% (p=0.000 n=10)
__CommandOutput_1M-8         162.4k ±  1%   114.4k ±  1%  -29.59% (p=0.000 n=9+10)
geomean                      2.343k         1.867k        -20.33%
```