### PR TITLE
fix: stop waiting if image cannot be pulled

### DIFF
--- a/pkg/executors/kubernetes_executor.go
+++ b/pkg/executors/kubernetes_executor.go
@@ -115,7 +115,7 @@ func (e *KubernetesExecutor) Start() int {
 	e.cancelFunc = cancel
 
 	err := e.k8sClient.WaitForPod(ctx, e.podName, func(msg string) {
-		e.logger.LogCommandOutput(msg)
+		e.logger.LogCommandOutput(msg + "\n")
 		log.Info(msg)
 	})
 
@@ -126,7 +126,8 @@ func (e *KubernetesExecutor) Start() int {
 		return exitCode
 	}
 
-	e.logger.LogCommandOutput("Starting a new bash session in the pod\n")
+	e.logger.LogCommandOutput("Pod is ready.\n")
+	e.logger.LogCommandOutput("Starting a new bash session in the pod...\n")
 
 	// #nosec
 	executable := "kubectl"
@@ -161,6 +162,7 @@ func (e *KubernetesExecutor) Start() int {
 		return exitCode
 	}
 
+	e.logger.LogCommandOutput("Shell session is ready.\n")
 	e.Shell = shell
 	return exitCode
 }

--- a/pkg/kubernetes/client.go
+++ b/pkg/kubernetes/client.go
@@ -378,7 +378,7 @@ func (c *KubernetesClient) WaitForPod(ctx context.Context, name string, logFn fu
 
 	// If we stopped the retrying,
 	// but still an error occurred, we need to report that
-	if r.err != nil {
+	if !r.continueWaiting && r.err != nil {
 		return r.err
 	}
 


### PR DESCRIPTION
Currently, if a container image can't be pulled, we keep waiting until the pod start timeout runs out. We should stop waiting immediately when we see an image pull error.