### PR TITLE
feat: add --kubernetes-allowed-images

### DIFF
--- a/main.go
+++ b/main.go
@@ -123,7 +123,8 @@ func RunListener(httpClient *http.Client, logfile io.Writer) {
 	_ = pflag.String(config.UploadJobLogs, config.UploadJobLogsConditionNever, "When should the agent upload the job logs as a job artifact. Default is never.")
 	_ = pflag.Bool(config.FailOnPreJobHookError, false, "Fail job if pre-job hook fails")
 	_ = pflag.Bool(config.KubernetesExecutor, false, "Use Kubernetes executor")
-	_ = pflag.String(config.KubernetesPodSpec, "", "Use a Kubernetes configmap to decorate the pod created to run the Semaphore job.")
+	_ = pflag.String(config.KubernetesPodSpec, "", "Use a Kubernetes configmap to decorate the pod created to run the Semaphore job")
+	_ = pflag.StringSlice(config.KubernetesAllowedImages, []string{}, "List of regexes for allowed images to use for the Kubernetes executor")
 	_ = pflag.Int(
 		config.KubernetesPodStartTimeout,
 		config.DefaultKubernetesPodStartTimeout,
@@ -200,6 +201,7 @@ func RunListener(httpClient *http.Client, logfile io.Writer) {
 		ExitOnShutdown:                   true,
 		KubernetesExecutor:               viper.GetBool(config.KubernetesExecutor),
 		KubernetesPodSpec:                viper.GetString(config.KubernetesPodSpec),
+		KubernetesAllowedImages:          viper.GetStringSlice(config.KubernetesAllowedImages),
 		KubernetesPodStartTimeoutSeconds: viper.GetInt(config.KubernetesPodStartTimeout),
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -21,6 +21,7 @@ const (
 	InterruptionGracePeriod    = "interruption-grace-period"
 	KubernetesExecutor         = "kubernetes-executor"
 	KubernetesPodSpec          = "kubernetes-pod-spec"
+	KubernetesAllowedImages    = "kubernetes-allowed-images"
 	KubernetesPodStartTimeout  = "kubernetes-pod-start-timeout"
 )
 
@@ -73,6 +74,7 @@ var ValidConfigKeys = []string{
 	InterruptionGracePeriod,
 	KubernetesExecutor,
 	KubernetesPodSpec,
+	KubernetesAllowedImages,
 	KubernetesPodStartTimeout,
 }
 

--- a/pkg/jobs/job.go
+++ b/pkg/jobs/job.go
@@ -49,6 +49,7 @@ type JobOptions struct {
 	UseKubernetesExecutor            bool
 	PodSpecDecoratorConfigMap        string
 	KubernetesPodStartTimeoutSeconds int
+	KubernetesImageValidator         *kubernetes.ImageValidator
 	UploadJobLogs                    string
 	RefreshTokenFn                   func() (string, error)
 }
@@ -119,6 +120,7 @@ func CreateExecutor(request *api.JobRequest, logger *eventlogger.Logger, jobOpti
 
 		return executors.NewKubernetesExecutor(request, logger, kubernetes.Config{
 			Namespace:                 namespace,
+			ImageValidator:            jobOptions.KubernetesImageValidator,
 			PodSpecDecoratorConfigMap: jobOptions.PodSpecDecoratorConfigMap,
 			PodPollingAttempts:        jobOptions.KubernetesPodStartTimeoutSeconds,
 			PodPollingInterval:        time.Second,

--- a/pkg/kubernetes/client.go
+++ b/pkg/kubernetes/client.go
@@ -26,6 +26,7 @@ import (
 
 type Config struct {
 	Namespace                 string
+	ImageValidator            *ImageValidator
 	PodSpecDecoratorConfigMap string
 	PodPollingAttempts        int
 	PodPollingInterval        time.Duration
@@ -340,6 +341,10 @@ func (c *KubernetesClient) imagePullSecrets(imagePullSecret string) []corev1.Loc
 
 func (c *KubernetesClient) containers(apiContainers []api.Container) ([]corev1.Container, error) {
 	if len(apiContainers) > 0 {
+		if err := c.config.ImageValidator.Validate(apiContainers); err != nil {
+			return []corev1.Container{}, fmt.Errorf("error validating images: %v", err)
+		}
+
 		return c.convertContainersFromSemaphore(apiContainers), nil
 	}
 

--- a/pkg/kubernetes/client_test.go
+++ b/pkg/kubernetes/client_test.go
@@ -136,7 +136,12 @@ func Test__CreateImagePullSecret(t *testing.T) {
 func Test__CreatePod(t *testing.T) {
 	t.Run("no containers from YAML -> error", func(t *testing.T) {
 		clientset := newFakeClientset([]runtime.Object{})
-		client, _ := NewKubernetesClient(clientset, Config{Namespace: "default"})
+		imageValidator, _ := NewImageValidator([]string{})
+		client, _ := NewKubernetesClient(clientset, Config{
+			Namespace:      "default",
+			ImageValidator: imageValidator,
+		})
+
 		_ = client.LoadPodSpec()
 		podName := "mypod"
 		envSecretName := "mysecret"
@@ -150,7 +155,12 @@ func Test__CreatePod(t *testing.T) {
 
 	t.Run("containers and no pod spec", func(t *testing.T) {
 		clientset := newFakeClientset([]runtime.Object{})
-		client, err := NewKubernetesClient(clientset, Config{Namespace: "default"})
+		imageValidator, _ := NewImageValidator([]string{})
+		client, err := NewKubernetesClient(clientset, Config{
+			Namespace:      "default",
+			ImageValidator: imageValidator,
+		})
+
 		if !assert.NoError(t, err) {
 			return
 		}
@@ -186,7 +196,13 @@ func Test__CreatePod(t *testing.T) {
 			podSpecWithImagePullPolicy("default", "Always"),
 		})
 
-		client, err := NewKubernetesClient(clientset, Config{Namespace: "default", PodSpecDecoratorConfigMap: "pod-spec"})
+		imageValidator, _ := NewImageValidator([]string{})
+		client, err := NewKubernetesClient(clientset, Config{
+			Namespace:                 "default",
+			PodSpecDecoratorConfigMap: "pod-spec",
+			ImageValidator:            imageValidator,
+		})
+
 		if !assert.NoError(t, err) {
 			return
 		}
@@ -226,7 +242,12 @@ func Test__CreatePod(t *testing.T) {
 
 	t.Run("container with env vars", func(t *testing.T) {
 		clientset := newFakeClientset([]runtime.Object{})
-		client, _ := NewKubernetesClient(clientset, Config{Namespace: "default"})
+		imageValidator, _ := NewImageValidator([]string{})
+		client, _ := NewKubernetesClient(clientset, Config{
+			Namespace:      "default",
+			ImageValidator: imageValidator,
+		})
+
 		_ = client.LoadPodSpec()
 		podName := "mypod"
 		envSecretName := "mysecret"
@@ -266,7 +287,13 @@ func Test__CreatePod(t *testing.T) {
 
 	t.Run("container with env vars + pod spec with env", func(t *testing.T) {
 		clientset := newFakeClientset([]runtime.Object{podSpecWithEnv("default")})
-		client, _ := NewKubernetesClient(clientset, Config{Namespace: "default", PodSpecDecoratorConfigMap: "pod-spec"})
+		imageValidator, _ := NewImageValidator([]string{})
+		client, _ := NewKubernetesClient(clientset, Config{
+			Namespace:                 "default",
+			PodSpecDecoratorConfigMap: "pod-spec",
+			ImageValidator:            imageValidator,
+		})
+
 		_ = client.LoadPodSpec()
 		podName := "mypod"
 		envSecretName := "mysecret"
@@ -310,7 +337,12 @@ func Test__CreatePod(t *testing.T) {
 
 	t.Run("multiple containers", func(t *testing.T) {
 		clientset := newFakeClientset([]runtime.Object{})
-		client, _ := NewKubernetesClient(clientset, Config{Namespace: "default"})
+		imageValidator, _ := NewImageValidator([]string{})
+		client, _ := NewKubernetesClient(clientset, Config{
+			Namespace:      "default",
+			ImageValidator: imageValidator,
+		})
+
 		_ = client.LoadPodSpec()
 		podName := "mypod"
 		envSecretName := "mysecret"
@@ -354,7 +386,12 @@ func Test__CreatePod(t *testing.T) {
 
 	t.Run("no image pull secrets", func(t *testing.T) {
 		clientset := newFakeClientset([]runtime.Object{})
-		client, _ := NewKubernetesClient(clientset, Config{Namespace: "default"})
+		imageValidator, _ := NewImageValidator([]string{})
+		client, _ := NewKubernetesClient(clientset, Config{
+			Namespace:      "default",
+			ImageValidator: imageValidator,
+		})
+
 		_ = client.LoadPodSpec()
 		podName := "mypod"
 
@@ -383,9 +420,11 @@ func Test__CreatePod(t *testing.T) {
 			podSpecWithImagePullSecret("default", "secret-1"),
 		})
 
+		imageValidator, _ := NewImageValidator([]string{})
 		client, err := NewKubernetesClient(clientset, Config{
 			Namespace:                 "default",
 			PodSpecDecoratorConfigMap: "pod-spec",
+			ImageValidator:            imageValidator,
 		})
 
 		if !assert.NoError(t, err) {
@@ -417,7 +456,12 @@ func Test__CreatePod(t *testing.T) {
 
 	t.Run("with image pull secret from YAML", func(t *testing.T) {
 		clientset := newFakeClientset([]runtime.Object{})
-		client, _ := NewKubernetesClient(clientset, Config{Namespace: "default"})
+		imageValidator, _ := NewImageValidator([]string{})
+		client, _ := NewKubernetesClient(clientset, Config{
+			Namespace:      "default",
+			ImageValidator: imageValidator,
+		})
+
 		_ = client.LoadPodSpec()
 		podName := "mypod"
 
@@ -446,9 +490,11 @@ func Test__CreatePod(t *testing.T) {
 			podSpecWithImagePullSecret("default", "secret-1"),
 		})
 
+		imageValidator, _ := NewImageValidator([]string{})
 		client, _ := NewKubernetesClient(clientset, Config{
 			Namespace:                 "default",
 			PodSpecDecoratorConfigMap: "pod-spec",
+			ImageValidator:            imageValidator,
 		})
 
 		_ = client.LoadPodSpec()
@@ -479,9 +525,11 @@ func Test__CreatePod(t *testing.T) {
 
 	t.Run("with resources", func(t *testing.T) {
 		clientset := newFakeClientset([]runtime.Object{podSpecWithResources("default")})
+		imageValidator, _ := NewImageValidator([]string{})
 		client, _ := NewKubernetesClient(clientset, Config{
 			Namespace:                 "default",
 			PodSpecDecoratorConfigMap: "pod-spec",
+			ImageValidator:            imageValidator,
 		})
 
 		_ = client.LoadPodSpec()

--- a/pkg/kubernetes/image_validator.go
+++ b/pkg/kubernetes/image_validator.go
@@ -36,6 +36,10 @@ func (v *ImageValidator) Validate(containers []api.Container) error {
 }
 
 func (v *ImageValidator) validateImage(image string) error {
+	if len(v.Expressions) == 0 {
+		return nil
+	}
+
 	for _, expression := range v.Expressions {
 		if expression.MatchString(image) {
 			return nil

--- a/pkg/kubernetes/image_validator.go
+++ b/pkg/kubernetes/image_validator.go
@@ -1,0 +1,46 @@
+package kubernetes
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/semaphoreci/agent/pkg/api"
+)
+
+type ImageValidator struct {
+	Expressions []regexp.Regexp
+}
+
+func NewImageValidator(expressions []string) (*ImageValidator, error) {
+	regexes := []regexp.Regexp{}
+	for _, exp := range expressions {
+		r, err := regexp.Compile(exp)
+		if err != nil {
+			return nil, err
+		}
+
+		regexes = append(regexes, *r)
+	}
+
+	return &ImageValidator{Expressions: regexes}, nil
+}
+
+func (v *ImageValidator) Validate(containers []api.Container) error {
+	for _, container := range containers {
+		if err := v.validateImage(container.Image); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (v *ImageValidator) validateImage(image string) error {
+	for _, expression := range v.Expressions {
+		if expression.MatchString(image) {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("image '%s' is not allowed", image)
+}

--- a/pkg/kubernetes/image_validator_test.go
+++ b/pkg/kubernetes/image_validator_test.go
@@ -1,0 +1,46 @@
+package kubernetes
+
+import (
+	"testing"
+
+	"github.com/semaphoreci/agent/pkg/api"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test__ImageValidator(t *testing.T) {
+	t.Run("no expressions => no restrictions", func(t *testing.T) {
+		imageValidator, err := NewImageValidator([]string{})
+		assert.NoError(t, err)
+		assert.NoError(t, imageValidator.Validate([]api.Container{
+			{Image: "registry.semaphoreci.com/ruby:2.7"},
+			{Image: "docker.io/redis"},
+			{Image: "postgres/9.6"},
+		}))
+	})
+
+	t.Run("single regex with all invalid images", func(t *testing.T) {
+		imageValidator, err := NewImageValidator([]string{
+			"^custom-registry-1\\.com\\/.+",
+		})
+
+		assert.NoError(t, err)
+		assert.ErrorContains(t, imageValidator.Validate([]api.Container{
+			{Image: "registry.semaphoreci.com/ruby:2.7"},
+			{Image: "docker.io/redis"},
+			{Image: "postgres/9.6"},
+		}), "image 'registry.semaphoreci.com/ruby:2.7' is not allowed")
+	})
+
+	t.Run("single regex with some invalid images", func(t *testing.T) {
+		imageValidator, err := NewImageValidator([]string{
+			"^registry\\.semaphoreci\\.com\\/.+",
+		})
+
+		assert.NoError(t, err)
+		assert.ErrorContains(t, imageValidator.Validate([]api.Container{
+			{Image: "registry.semaphoreci.com/ruby:2.7"},
+			{Image: "docker.io/redis"},
+			{Image: "postgres/9.6"},
+		}), "image 'docker.io/redis' is not allowed")
+	})
+}

--- a/pkg/kubernetes/image_validator_test.go
+++ b/pkg/kubernetes/image_validator_test.go
@@ -8,6 +8,11 @@ import (
 )
 
 func Test__ImageValidator(t *testing.T) {
+	t.Run("bad expression => error creating validator", func(t *testing.T) {
+		_, err := NewImageValidator([]string{"(.*)\\((.*)\\) ?(? U)"})
+		assert.Error(t, err)
+	})
+
 	t.Run("no expressions => no restrictions", func(t *testing.T) {
 		imageValidator, err := NewImageValidator([]string{})
 		assert.NoError(t, err)

--- a/pkg/listener/job_processor.go
+++ b/pkg/listener/job_processor.go
@@ -23,11 +23,6 @@ import (
 )
 
 func StartJobProcessor(httpClient *http.Client, apiClient *selfhostedapi.API, config Config) (*JobProcessor, error) {
-	imageValidator, err := kubernetes.NewImageValidator(config.KubernetesAllowedImages)
-	if err != nil {
-		return nil, err
-	}
-
 	p := &JobProcessor{
 		HTTPClient:                       httpClient,
 		APIClient:                        apiClient,
@@ -46,7 +41,7 @@ func StartJobProcessor(httpClient *http.Client, apiClient *selfhostedapi.API, co
 		ExitOnShutdown:                   config.ExitOnShutdown,
 		KubernetesExecutor:               config.KubernetesExecutor,
 		KubernetesPodSpec:                config.KubernetesPodSpec,
-		KubernetesImageValidator:         imageValidator,
+		KubernetesImageValidator:         config.KubernetesImageValidator,
 		KubernetesPodStartTimeoutSeconds: config.KubernetesPodStartTimeoutSeconds,
 	}
 

--- a/pkg/listener/listener.go
+++ b/pkg/listener/listener.go
@@ -41,6 +41,7 @@ type Config struct {
 	AgentName                        string
 	KubernetesExecutor               bool
 	KubernetesPodSpec                string
+	KubernetesAllowedImages          []string
 	KubernetesPodStartTimeoutSeconds int
 }
 

--- a/pkg/listener/listener.go
+++ b/pkg/listener/listener.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/semaphoreci/agent/pkg/config"
+	"github.com/semaphoreci/agent/pkg/kubernetes"
 	selfhostedapi "github.com/semaphoreci/agent/pkg/listener/selfhostedapi"
 	osinfo "github.com/semaphoreci/agent/pkg/osinfo"
 	"github.com/semaphoreci/agent/pkg/retry"
@@ -41,7 +42,7 @@ type Config struct {
 	AgentName                        string
 	KubernetesExecutor               bool
 	KubernetesPodSpec                string
-	KubernetesAllowedImages          []string
+	KubernetesImageValidator         *kubernetes.ImageValidator
 	KubernetesPodStartTimeoutSeconds int
 }
 


### PR DESCRIPTION
Currently, there's no way to restrict the images a job can use. Here, we introduce a `--kubernetes-allowed-images` parameter. It takes a list of regexes. If all the images specified in the job match one of the regexes, the job will run. Otherwise, it will fail.