### PR TITLE
fix: filebackend.Read() should not return double newlines

### DIFF
--- a/pkg/eventlogger/filebackend.go
+++ b/pkg/eventlogger/filebackend.go
@@ -118,7 +118,7 @@ func (l *FileBackend) Read(startingLineNumber, maxLines int, writer io.Writer) (
 
 		// Otherwise, we advance to the next line and stream the current line.
 		lineNumber++
-		fmt.Fprintln(writer, line)
+		fmt.Fprint(writer, line)
 		linesStreamed++
 
 		// if we have streamed the number of lines we want, we stop.


### PR DESCRIPTION
`bufio.Reader.ReadString('\n')` includes the delimiter (`\n`) in the returned data, so we shouldn't use `fmt.Fprintln()` since the data being written already has the newline in it.