### PR TITLE
feat: add --source-pre-job-hook parameter

### DIFF
--- a/main.go
+++ b/main.go
@@ -123,6 +123,7 @@ func RunListener(httpClient *http.Client, logfile io.Writer) {
 	_ = pflag.Bool(config.FailOnMissingFiles, false, "Fail job if files specified using --files are missing")
 	_ = pflag.String(config.UploadJobLogs, config.UploadJobLogsConditionNever, "When should the agent upload the job logs as a job artifact. Default is never.")
 	_ = pflag.Bool(config.FailOnPreJobHookError, false, "Fail job if pre-job hook fails")
+	_ = pflag.Bool(config.SourcePreJobHook, false, "Execute pre-job hook in the current shell (using 'source <script>') instead of in a new shell (using 'bash <script>')")
 	_ = pflag.Bool(config.KubernetesExecutor, false, "Use Kubernetes executor")
 	_ = pflag.String(config.KubernetesPodSpec, "", "Use a Kubernetes configmap to decorate the pod created to run the Semaphore job")
 	_ = pflag.StringSlice(config.KubernetesAllowedImages, []string{}, "List of regexes for allowed images to use for the Kubernetes executor")
@@ -198,6 +199,7 @@ func RunListener(httpClient *http.Client, logfile io.Writer) {
 		FailOnMissingFiles:               viper.GetBool(config.FailOnMissingFiles),
 		UploadJobLogs:                    viper.GetString(config.UploadJobLogs),
 		FailOnPreJobHookError:            viper.GetBool(config.FailOnPreJobHookError),
+		SourcePreJobHook:                 viper.GetBool(config.SourcePreJobHook),
 		AgentVersion:                     VERSION,
 		ExitOnShutdown:                   true,
 		KubernetesExecutor:               viper.GetBool(config.KubernetesExecutor),

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -18,6 +18,7 @@ const (
 	FailOnMissingFiles         = "fail-on-missing-files"
 	UploadJobLogs              = "upload-job-logs"
 	FailOnPreJobHookError      = "fail-on-pre-job-hook-error"
+	SourcePreJobHook           = "source-pre-job-hook"
 	InterruptionGracePeriod    = "interruption-grace-period"
 	KubernetesExecutor         = "kubernetes-executor"
 	KubernetesPodSpec          = "kubernetes-pod-spec"
@@ -71,6 +72,7 @@ var ValidConfigKeys = []string{
 	FailOnMissingFiles,
 	UploadJobLogs,
 	FailOnPreJobHookError,
+	SourcePreJobHook,
 	InterruptionGracePeriod,
 	KubernetesExecutor,
 	KubernetesPodSpec,

--- a/pkg/jobs/job.go
+++ b/pkg/jobs/job.go
@@ -148,6 +148,7 @@ type RunOptions struct {
 	FileInjections        []config.FileInjection
 	PreJobHookPath        string
 	FailOnPreJobHookError bool
+	SourcePreJobHook      bool
 	OnJobFinished         func(selfhostedapi.JobResult)
 	CallbackRetryAttempts int
 }
@@ -173,6 +174,16 @@ func (o *RunOptions) GetPreJobHookCommand() string {
 	 */
 	if runtime.GOOS == "windows" {
 		return o.PreJobHookPath
+	}
+
+	/*
+	 * This executes the pre-job hook without opening a new shell.
+	 * That means that changes to the environment performed in the hook
+	 * (current directory, environment variables, export commands)
+	 * will be visible by the next job commands.
+	 */
+	if o.SourcePreJobHook {
+		return fmt.Sprintf("source %s", o.PreJobHookPath)
 	}
 
 	return fmt.Sprintf("bash %s", o.PreJobHookPath)

--- a/pkg/listener/job_processor.go
+++ b/pkg/listener/job_processor.go
@@ -38,6 +38,7 @@ func StartJobProcessor(httpClient *http.Client, apiClient *selfhostedapi.API, co
 		FailOnMissingFiles:               config.FailOnMissingFiles,
 		UploadJobLogs:                    config.UploadJobLogs,
 		FailOnPreJobHookError:            config.FailOnPreJobHookError,
+		SourcePreJobHook:                 config.SourcePreJobHook,
 		ExitOnShutdown:                   config.ExitOnShutdown,
 		KubernetesExecutor:               config.KubernetesExecutor,
 		KubernetesPodSpec:                config.KubernetesPodSpec,
@@ -79,6 +80,7 @@ type JobProcessor struct {
 	FailOnMissingFiles               bool
 	UploadJobLogs                    string
 	FailOnPreJobHookError            bool
+	SourcePreJobHook                 bool
 	ExitOnShutdown                   bool
 	KubernetesExecutor               bool
 	KubernetesPodSpec                string
@@ -199,6 +201,7 @@ func (p *JobProcessor) RunJob(jobID string) {
 		EnvVars:               p.EnvVars,
 		PreJobHookPath:        p.PreJobHookPath,
 		FailOnPreJobHookError: p.FailOnPreJobHookError,
+		SourcePreJobHook:      p.SourcePreJobHook,
 		CallbackRetryAttempts: p.CallbackRetryAttempts,
 		FileInjections:        p.FileInjections,
 		OnJobFinished:         p.JobFinished,

--- a/pkg/listener/listener.go
+++ b/pkg/listener/listener.go
@@ -37,6 +37,7 @@ type Config struct {
 	FailOnMissingFiles               bool
 	UploadJobLogs                    string
 	FailOnPreJobHookError            bool
+	SourcePreJobHook                 bool
 	ExitOnShutdown                   bool
 	AgentVersion                     string
 	AgentName                        string


### PR DESCRIPTION
We execute the pre-job hook using `bash <hook-path>`. That executes the script in a new shell, and environment changes performed during the hook execution are not carried to the shell used for the job commands. However, in some cases, it is helpful to persist in the environment changed by the pre-job hook. For example, if you want to install the Semaphore toolbox on every job in the pre-job hook.

This pull request adds a new parameter: `--source-pre-job-hook`, which instructs the agent to use `source <hook-path>` instead. By default, that parameter is false, so we keep the current behavior.