### PR TITLE
feat: post-job hook

### DIFF
--- a/main.go
+++ b/main.go
@@ -115,6 +115,7 @@ func RunListener(httpClient *http.Client, logfile io.Writer) {
 	_ = pflag.Bool(config.NoHTTPS, false, "Use http for communication")
 	_ = pflag.String(config.ShutdownHookPath, "", "Shutdown hook path")
 	_ = pflag.String(config.PreJobHookPath, "", "Pre-job hook path")
+	_ = pflag.String(config.PostJobHookPath, "", "Post-job hook path")
 	_ = pflag.Bool(config.DisconnectAfterJob, false, "Disconnect after job")
 	_ = pflag.Int(config.DisconnectAfterIdleTimeout, 0, "Disconnect after idle timeout, in seconds")
 	_ = pflag.Int(config.InterruptionGracePeriod, 0, "The grace period, in seconds, to wait after receiving an interrupt signal")
@@ -191,6 +192,7 @@ func RunListener(httpClient *http.Client, logfile io.Writer) {
 		Scheme:                           scheme,
 		ShutdownHookPath:                 viper.GetString(config.ShutdownHookPath),
 		PreJobHookPath:                   viper.GetString(config.PreJobHookPath),
+		PostJobHookPath:                  viper.GetString(config.PostJobHookPath),
 		DisconnectAfterJob:               viper.GetBool(config.DisconnectAfterJob),
 		DisconnectAfterIdleSeconds:       viper.GetInt(config.DisconnectAfterIdleTimeout),
 		InterruptionGracePeriod:          viper.GetInt(config.InterruptionGracePeriod),

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -11,6 +11,7 @@ const (
 	NoHTTPS                    = "no-https"
 	ShutdownHookPath           = "shutdown-hook-path"
 	PreJobHookPath             = "pre-job-hook-path"
+	PostJobHookPath            = "post-job-hook-path"
 	DisconnectAfterJob         = "disconnect-after-job"
 	DisconnectAfterIdleTimeout = "disconnect-after-idle-timeout"
 	EnvVars                    = "env-vars"
@@ -65,6 +66,7 @@ var ValidConfigKeys = []string{
 	NoHTTPS,
 	ShutdownHookPath,
 	PreJobHookPath,
+	PostJobHookPath,
 	DisconnectAfterJob,
 	DisconnectAfterIdleTimeout,
 	EnvVars,

--- a/pkg/listener/job_processor.go
+++ b/pkg/listener/job_processor.go
@@ -33,6 +33,7 @@ func StartJobProcessor(httpClient *http.Client, apiClient *selfhostedapi.API, co
 		CallbackRetryAttempts:            config.CallbackRetryLimit,
 		ShutdownHookPath:                 config.ShutdownHookPath,
 		PreJobHookPath:                   config.PreJobHookPath,
+		PostJobHookPath:                  config.PostJobHookPath,
 		EnvVars:                          config.EnvVars,
 		FileInjections:                   config.FileInjections,
 		FailOnMissingFiles:               config.FailOnMissingFiles,
@@ -74,6 +75,7 @@ type JobProcessor struct {
 	CallbackRetryAttempts            int
 	ShutdownHookPath                 string
 	PreJobHookPath                   string
+	PostJobHookPath                  string
 	StopSync                         bool
 	EnvVars                          []config.HostEnvVar
 	FileInjections                   []config.FileInjection
@@ -200,6 +202,7 @@ func (p *JobProcessor) RunJob(jobID string) {
 	go job.RunWithOptions(jobs.RunOptions{
 		EnvVars:               p.EnvVars,
 		PreJobHookPath:        p.PreJobHookPath,
+		PostJobHookPath:       p.PostJobHookPath,
 		FailOnPreJobHookError: p.FailOnPreJobHookError,
 		SourcePreJobHook:      p.SourcePreJobHook,
 		CallbackRetryAttempts: p.CallbackRetryAttempts,

--- a/pkg/listener/listener.go
+++ b/pkg/listener/listener.go
@@ -29,6 +29,7 @@ type Config struct {
 	Scheme                           string
 	ShutdownHookPath                 string
 	PreJobHookPath                   string
+	PostJobHookPath                  string
 	DisconnectAfterJob               bool
 	DisconnectAfterIdleSeconds       int
 	InterruptionGracePeriod          int


### PR DESCRIPTION
The new `post-job` hook is a way to execute a script after the job is finished.
- The script executes after the job's regular commands and after the epilogue commands (if those are configured).
- The script is executed before the PTY is terminated, so it has access to the environment variables exposed through the job.
- The result of the post-job hook execution does not interfere with the job's result, just like the epilogue commands don't either.