### PR TITLE
feat: support --pre-job-hook-path and --files on agent serve

### DIFF
--- a/pkg/jobs/job.go
+++ b/pkg/jobs/job.go
@@ -145,7 +145,6 @@ func CreateExecutor(request *api.JobRequest, logger *eventlogger.Logger, jobOpti
 
 type RunOptions struct {
 	EnvVars               []config.HostEnvVar
-	FileInjections        []config.FileInjection
 	PreJobHookPath        string
 	PostJobHookPath       string
 	FailOnPreJobHookError bool
@@ -207,7 +206,6 @@ func (o *RunOptions) GetPostJobHookCommand() string {
 func (job *Job) Run() {
 	job.RunWithOptions(RunOptions{
 		EnvVars:               []config.HostEnvVar{},
-		FileInjections:        []config.FileInjection{},
 		PreJobHookPath:        "",
 		PostJobHookPath:       "",
 		OnJobFinished:         nil,

--- a/pkg/jobs/job_test.go
+++ b/pkg/jobs/job_test.go
@@ -1033,7 +1033,6 @@ func Test__UsePreJobHook(t *testing.T) {
 
 	job.RunWithOptions(RunOptions{
 		EnvVars:               []config.HostEnvVar{},
-		FileInjections:        []config.FileInjection{},
 		PreJobHookPath:        hook,
 		OnJobFinished:         nil,
 		CallbackRetryAttempts: 1,
@@ -1100,7 +1099,6 @@ func Test__UsePostJobHook(t *testing.T) {
 
 	job.RunWithOptions(RunOptions{
 		EnvVars:               []config.HostEnvVar{},
-		FileInjections:        []config.FileInjection{},
 		PostJobHookPath:       hook,
 		OnJobFinished:         nil,
 		CallbackRetryAttempts: 1,
@@ -1175,7 +1173,6 @@ func Test__PreJobHookHasAccessToEnvVars(t *testing.T) {
 	_ = ioutil.WriteFile(hook, []byte(strings.Join(hookContent, "\n")), 0777)
 	job.RunWithOptions(RunOptions{
 		EnvVars:               []config.HostEnvVar{},
-		FileInjections:        []config.FileInjection{},
 		PreJobHookPath:        hook,
 		OnJobFinished:         nil,
 		CallbackRetryAttempts: 1,
@@ -1249,7 +1246,6 @@ func Test__PostJobHookHasAccessToEnvVars(t *testing.T) {
 	_ = ioutil.WriteFile(hook, []byte(strings.Join(hookContent, "\n")), 0777)
 	job.RunWithOptions(RunOptions{
 		EnvVars:               []config.HostEnvVar{},
-		FileInjections:        []config.FileInjection{},
 		PostJobHookPath:       hook,
 		OnJobFinished:         nil,
 		CallbackRetryAttempts: 1,
@@ -1314,7 +1310,6 @@ func Test__UsePreJobHookAndFailOnError(t *testing.T) {
 
 	job.RunWithOptions(RunOptions{
 		EnvVars:               []config.HostEnvVar{},
-		FileInjections:        []config.FileInjection{},
 		PreJobHookPath:        hook,
 		FailOnPreJobHookError: true,
 		OnJobFinished:         nil,

--- a/pkg/listener/job_processor.go
+++ b/pkg/listener/job_processor.go
@@ -206,7 +206,6 @@ func (p *JobProcessor) RunJob(jobID string) {
 		FailOnPreJobHookError: p.FailOnPreJobHookError,
 		SourcePreJobHook:      p.SourcePreJobHook,
 		CallbackRetryAttempts: p.CallbackRetryAttempts,
-		FileInjections:        p.FileInjections,
 		OnJobFinished:         p.JobFinished,
 	})
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -221,6 +221,7 @@ func (s *Server) Run(w http.ResponseWriter, r *http.Request) {
 	go s.ActiveJob.RunWithOptions(jobs.RunOptions{
 		EnvVars:               []config.HostEnvVar{},
 		PreJobHookPath:        s.Config.PreJobHookPath,
+		FailOnPreJobHookError: true, // cloud jobs should always fail if the pre-job hook fails
 		PostJobHookPath:       "",
 		OnJobFinished:         nil,
 		CallbackRetryAttempts: 60,


### PR DESCRIPTION
Currently, for cloud jobs, the Semaphore server inserts a few commands at the beginning of jobs:
- Install toolbox
- Start ssh-agent
- Connect to cache

We should move these commands from the Semaphore server to the agent. For self-hosted agents (`agent start`), we have [pre-job hooks](https://docs.semaphoreci.com/ci-cd-environment/configure-self-hosted-agent/#pre-job-hook-path), which allows the configuration of commands to execute before a job starts at the agent level. Now that we intend to support Windows agents in the cloud, we need that same behavior for cloud agents (`agent serve`).