### PR TITLE
feat: follow API instructions on when to sync next

### DIFF
--- a/pkg/listener/job_processor.go
+++ b/pkg/listener/job_processor.go
@@ -109,9 +109,9 @@ func (p *JobProcessor) SyncLoop() {
 		// or we immediately sync if a state change was detected.
 		select {
 		case <-p.forceSyncCh:
-			log.Infof("Forcing sync due to state change")
+			log.Debug("Forcing sync due to state change")
 		case <-time.After(*nextSyncInterval):
-			log.Infof("Delay requested by API expired")
+			log.Debug("Delay requested by API expired")
 		}
 	}
 }
@@ -264,7 +264,6 @@ func (p *JobProcessor) StopJob(jobID string) {
 	p.State = selfhostedapi.AgentStateStoppingJob
 
 	p.CurrentJob.Stop()
-	p.forceSyncCh <- true
 }
 
 func (p *JobProcessor) JobFinished(result selfhostedapi.JobResult) {

--- a/pkg/listener/job_processor.go
+++ b/pkg/listener/job_processor.go
@@ -127,8 +127,7 @@ func (p *JobProcessor) Sync() time.Duration {
 	response, err := p.APIClient.Sync(request)
 	if err != nil {
 		p.HandleSyncError(err)
-		delay, _ := random.DurationInRange(3000, 6000)
-		return *delay
+		return p.defaultSyncInterval()
 	}
 
 	p.LastSuccessfulSync = time.Now()
@@ -147,7 +146,7 @@ func (p *JobProcessor) findNextSyncInterval(response *selfhostedapi.SyncResponse
 		return time.Until(nextSyncAt)
 	}
 
-	log.Debugf("No next_sync_at field on sync response - using default interval", response.NextSyncAt)
+	log.Debug("No next_sync_at field on sync response - using default interval")
 	return p.defaultSyncInterval()
 }
 

--- a/pkg/listener/job_processor.go
+++ b/pkg/listener/job_processor.go
@@ -136,14 +136,8 @@ func (p *JobProcessor) Sync() time.Duration {
 }
 
 func (p *JobProcessor) findNextSyncInterval(response *selfhostedapi.SyncResponse) time.Duration {
-	if response.NextSyncAt != "" {
-		nextSyncAt, err := time.Parse(time.RFC3339Nano, response.NextSyncAt)
-		if err != nil {
-			log.Errorf("Error parsing next sync at '%s': %v - using default interval", response.NextSyncAt, err)
-			return p.defaultSyncInterval()
-		}
-
-		return time.Until(nextSyncAt)
+	if response.NextSyncAfter > 0 {
+		return time.Duration(response.NextSyncAfter) * time.Millisecond
 	}
 
 	log.Debug("No next_sync_at field on sync response - using default interval")

--- a/pkg/listener/selfhostedapi/sync.go
+++ b/pkg/listener/selfhostedapi/sync.go
@@ -47,7 +47,7 @@ type SyncResponse struct {
 	Action         AgentAction    `json:"action"`
 	JobID          string         `json:"job_id"`
 	ShutdownReason ShutdownReason `json:"shutdown_reason"`
-	NextSyncAt     int64          `json:"next_sync_at"`
+	NextSyncAt     string         `json:"next_sync_at"`
 }
 
 func (a *API) SyncPath() string {

--- a/pkg/listener/selfhostedapi/sync.go
+++ b/pkg/listener/selfhostedapi/sync.go
@@ -47,6 +47,7 @@ type SyncResponse struct {
 	Action         AgentAction    `json:"action"`
 	JobID          string         `json:"job_id"`
 	ShutdownReason ShutdownReason `json:"shutdown_reason"`
+	NextSyncAt     int64          `json:"next_sync_at"`
 }
 
 func (a *API) SyncPath() string {

--- a/pkg/listener/selfhostedapi/sync.go
+++ b/pkg/listener/selfhostedapi/sync.go
@@ -47,7 +47,7 @@ type SyncResponse struct {
 	Action         AgentAction    `json:"action"`
 	JobID          string         `json:"job_id"`
 	ShutdownReason ShutdownReason `json:"shutdown_reason"`
-	NextSyncAt     string         `json:"next_sync_at"`
+	NextSyncAfter  int            `json:"next_sync_after"`
 }
 
 func (a *API) SyncPath() string {

--- a/test/support/hub.go
+++ b/test/support/hub.go
@@ -140,7 +140,8 @@ func (m *HubMockServer) handleSyncRequest(w http.ResponseWriter, r *http.Request
 	fmt.Printf("[HUB MOCK] Received sync request: %v\n", request)
 
 	syncResponse := selfhostedapi.SyncResponse{
-		Action: selfhostedapi.AgentActionContinue,
+		Action:     selfhostedapi.AgentActionContinue,
+		NextSyncAt: time.Now().Add(5 * time.Second).Format(time.RFC3339Nano),
 	}
 
 	switch request.State {

--- a/test/support/hub.go
+++ b/test/support/hub.go
@@ -140,8 +140,8 @@ func (m *HubMockServer) handleSyncRequest(w http.ResponseWriter, r *http.Request
 	fmt.Printf("[HUB MOCK] Received sync request: %v\n", request)
 
 	syncResponse := selfhostedapi.SyncResponse{
-		Action:     selfhostedapi.AgentActionContinue,
-		NextSyncAt: time.Now().Add(5 * time.Second).Format(time.RFC3339Nano),
+		Action:        selfhostedapi.AgentActionContinue,
+		NextSyncAfter: 1000,
 	}
 
 	switch request.State {


### PR DESCRIPTION
Use the new `next_sync_after` field of the API sync response. That field is an integer specifying the number of milliseconds to wait before the next sync request. Additionally, the agent should not wait for that interval to pass if (1) the job is finished or (2) the agent was interrupted. In those cases, we trigger a new sync request even if the interval requested by the API has not passed yet.