### PR TITLE
fix: goreleaser configuration

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -32,27 +32,30 @@ archives:
   - id: non-windows-archive
     builds:
       - non-windows-build
-    name_template: '{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
     files:
       - README.md
       - install.sh
-    replacements:
-      darwin: Darwin
-      linux: Linux
-      386: i386
-      amd64: x86_64
 
   - id: windows-archive
     builds:
       - windows-build
-    name_template: '{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
     files:
       - README.md
       - install.ps1
-    replacements:
-      386: i386
-      amd64: x86_64
-      windows: Windows
 
 checksum:
   name_template: '{{ .ProjectName }}_checksums.txt'
@@ -66,7 +69,7 @@ changelog:
     - Merge branch
 
 brews:
-  - tap:
+  - repository:
       owner: semaphoreci
       name: homebrew-tap
     commit_author:

--- a/.semaphore/release.yml
+++ b/.semaphore/release.yml
@@ -22,4 +22,4 @@ blocks:
         - name: Sem Agent
           commands:
             - export GITHUB_TOKEN=$ACCESS_TOKEN
-            - curl -sL https://git.io/goreleaser | bash -s -- --rm-dist
+            - curl -sL https://git.io/goreleaser | bash -s -- --clean


### PR DESCRIPTION
Goreleaser v1.19.x does not support `replacements`. Also, `--rm-dist` is deprecated in favor of `--clean`.