### PR TITLE
fix: cleanup resources even if shell fails to close

### DIFF
--- a/pkg/executors/kubernetes_executor.go
+++ b/pkg/executors/kubernetes_executor.go
@@ -375,8 +375,6 @@ func (e *KubernetesExecutor) Stop() int {
 		err := e.Shell.Close()
 		if err != nil {
 			log.Errorf("Process killing procedure returned an error %+v\n", err)
-
-			return 0
 		}
 	}
 


### PR DESCRIPTION
If something goes wrong when closing the shell, we should still clean up the resources we created for the job.