### PR TITLE
fix: use job ID as pod name

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,27 @@
+FROM ubuntu:20.04
+
+ARG USERNAME=semaphore
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+# Create the user
+RUN groupadd --gid $USER_GID $USERNAME && \
+  useradd --uid $USER_UID --gid $USER_GID -m $USERNAME
+
+RUN apt-get update -y && apt-get install -y ca-certificates curl
+RUN update-ca-certificates
+
+# kubectl is required to be present in the container running the agent
+RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+RUN install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
+
+# Install Semaphore agent
+RUN mkdir -p /opt/semaphore
+ADD build/agent /opt/semaphore/agent
+RUN chown ${USER_UID}:${USER_GID} /opt/semaphore
+
+USER $USERNAME
+WORKDIR /home/semaphore
+HEALTHCHECK NONE
+
+CMD ["/opt/semaphore/agent", "start", "--config-file", "/opt/semaphore/semaphore-agent.yml"]

--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,10 @@ ecr.test.push:
 	docker tag agent-testing:latest $(AWS_ECR_REGISTRY)/agent-testing:latest
 	docker push $(AWS_ECR_REGISTRY)/agent-testing:latest
 
+# Helpful when developing and testing locally
+docker.build.dev:
+	docker build -f Dockerfile.dev -t semaphoreci/agent:dev .
+
 #
 # Docker Release
 #

--- a/pkg/api/job_request.go
+++ b/pkg/api/job_request.go
@@ -92,7 +92,7 @@ func (p *PublicKey) Decode() ([]byte, error) {
 }
 
 type JobRequest struct {
-	JobID         string      `json:"job_id" yaml:"id"`
+	JobID         string      `json:"job_id" yaml:"job_id"`
 	Executor      string      `json:"executor" yaml:"executor"`
 	Compose       Compose     `json:"compose" yaml:"compose"`
 	Commands      []Command   `json:"commands" yaml:"commands"`

--- a/pkg/api/job_request.go
+++ b/pkg/api/job_request.go
@@ -92,7 +92,7 @@ func (p *PublicKey) Decode() ([]byte, error) {
 }
 
 type JobRequest struct {
-	ID            string      `json:"id" yaml:"id"`
+	JobID         string      `json:"job_id" yaml:"id"`
 	Executor      string      `json:"executor" yaml:"executor"`
 	Compose       Compose     `json:"compose" yaml:"compose"`
 	Commands      []Command   `json:"commands" yaml:"commands"`

--- a/pkg/executors/kubernetes_executor.go
+++ b/pkg/executors/kubernetes_executor.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"math/rand"
 	"os"
 	"path/filepath"
 	"time"
@@ -78,7 +77,7 @@ func (e *KubernetesExecutor) Prepare() int {
 		return exitCode
 	}
 
-	e.podName = e.randomPodName()
+	e.podName = fmt.Sprintf("semaphore-job-%s", e.jobRequest.JobID)
 	e.envSecretName = fmt.Sprintf("%s-secret", e.podName)
 	err = e.k8sClient.CreateSecret(e.envSecretName, e.jobRequest)
 	if err != nil {
@@ -110,17 +109,6 @@ func (e *KubernetesExecutor) Prepare() int {
 	}
 
 	return 0
-}
-
-func (e *KubernetesExecutor) randomPodName() string {
-	var letterRunes = []rune("abcdefghijklmnopqrstuvwxyz0123456789")
-
-	b := make([]rune, 12)
-	for i := range b {
-		b[i] = letterRunes[rand.Intn(len(letterRunes))]
-	}
-
-	return string(b)
 }
 
 func (e *KubernetesExecutor) Start() int {

--- a/pkg/jobs/job.go
+++ b/pkg/jobs/job.go
@@ -214,7 +214,7 @@ func (job *Job) Run() {
 }
 
 func (job *Job) RunWithOptions(options RunOptions) {
-	log.Infof("Running job %s", job.Request.ID)
+	log.Infof("Running job %s", job.Request.JobID)
 	executorRunning := false
 	result := JobFailed
 

--- a/pkg/listener/listener_test.go
+++ b/pkg/listener/listener_test.go
@@ -268,7 +268,7 @@ func Test__ShutdownAfterJobFinished(t *testing.T) {
 	assert.Nil(t, err)
 
 	hubMockServer.AssignJob(&api.JobRequest{
-		ID: "Test__ShutdownAfterJobFinished",
+		JobID: "Test__ShutdownAfterJobFinished",
 		Commands: []api.Command{
 			{Directive: testsupport.Output("hello world")},
 		},
@@ -383,7 +383,7 @@ func Test__ShutdownAfterInterruptionNoGracePeriod(t *testing.T) {
 
 	// assigns job that sleeps for 60s
 	hubMockServer.AssignJob(&api.JobRequest{
-		ID: "Test__ShutdownAfterJobFinished",
+		JobID: "Test__ShutdownAfterJobFinished",
 		Commands: []api.Command{
 			{Directive: "sleep 60"},
 		},
@@ -441,7 +441,7 @@ func Test__ShutdownAfterInterruptionWithGracePeriod(t *testing.T) {
 
 	// assigns job that sleeps for 10s
 	hubMockServer.AssignJob(&api.JobRequest{
-		ID: "Test__ShutdownAfterJobFinished",
+		JobID: "Test__ShutdownAfterJobFinished",
 		Commands: []api.Command{
 			{Directive: "sleep 15"},
 		},
@@ -531,7 +531,7 @@ func Test__ShutdownFromUpstreamWhileRunningJob(t *testing.T) {
 	assert.Nil(t, err)
 
 	hubMockServer.AssignJob(&api.JobRequest{
-		ID: "Test__ShutdownFromUpstreamWhileRunningJob",
+		JobID: "Test__ShutdownFromUpstreamWhileRunningJob",
 		Commands: []api.Command{
 			{Directive: "sleep 300"},
 		},
@@ -585,7 +585,7 @@ func Test__HostEnvVarsAreExposedToJob(t *testing.T) {
 	assert.Nil(t, err)
 
 	hubMockServer.AssignJob(&api.JobRequest{
-		ID: "Test__HostEnvVarsAreExposedToJob",
+		JobID: "Test__HostEnvVarsAreExposedToJob",
 		Commands: []api.Command{
 			{Directive: testsupport.Output("On regular commands")},
 			{Directive: testsupport.EchoEnvVar("IMPORTANT_HOST_VAR_A")},
@@ -718,7 +718,7 @@ func Test__LogTokenIsRefreshed(t *testing.T) {
 	assert.False(t, hubMockServer.TokenIsRefreshed)
 
 	hubMockServer.AssignJob(&api.JobRequest{
-		ID: "Test__LogTokenIsRefreshed",
+		JobID: "Test__LogTokenIsRefreshed",
 		Commands: []api.Command{
 			{Directive: testsupport.Output("hello")},
 		},
@@ -796,7 +796,7 @@ func Test__GetJobIsRetried(t *testing.T) {
 	assert.Nil(t, err)
 
 	hubMockServer.AssignJob(&api.JobRequest{
-		ID: "Test__GetJobIsRetried",
+		JobID: "Test__GetJobIsRetried",
 		Commands: []api.Command{
 			{Directive: testsupport.Output("hello")},
 		},
@@ -848,7 +848,7 @@ func Test__ReportsFailedToFetchJob(t *testing.T) {
 	assert.Nil(t, err)
 
 	hubMockServer.AssignJob(&api.JobRequest{
-		ID:       "Test__ReportsFailedToFetchJob",
+		JobID:    "Test__ReportsFailedToFetchJob",
 		Commands: []api.Command{},
 		Callbacks: api.Callbacks{
 			Finished:         "https://httpbin.org/status/200",
@@ -897,7 +897,7 @@ func Test__ReportsFailedToConstructJob(t *testing.T) {
 	assert.Nil(t, err)
 
 	hubMockServer.AssignJob(&api.JobRequest{
-		ID:       "Test__ReportsFailedToConstructJob",
+		JobID:    "Test__ReportsFailedToConstructJob",
 		Executor: "doesnotexist",
 		Commands: []api.Command{},
 		Callbacks: api.Callbacks{

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -182,7 +182,7 @@ func (s *Server) Run(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if s.State != ServerStateWaitingForJob {
-		if s.ActiveJob != nil && s.ActiveJob.Request.ID == request.ID {
+		if s.ActiveJob != nil && s.ActiveJob.Request.JobID == request.JobID {
 			// idempotent call
 			fmt.Fprint(w, `{"message": "ok"}`)
 			return

--- a/test/e2e/docker/broken_unicode.rb
+++ b/test/e2e/docker/broken_unicode.rb
@@ -8,7 +8,7 @@ require_relative '../../e2e'
 
 start_job <<-JSON
   {
-    "id": "#{$JOB_ID}",
+    "job_id": "#{$JOB_ID}",
 
     "executor": "dockercompose",
 

--- a/test/e2e/docker/check_dev_kvm.rb
+++ b/test/e2e/docker/check_dev_kvm.rb
@@ -5,7 +5,7 @@ require_relative '../../e2e'
 
 start_job <<-JSON
   {
-    "id": "#{$JOB_ID}",
+    "job_id": "#{$JOB_ID}",
 
     "executor": "dockercompose",
 

--- a/test/e2e/docker/command_aliases.rb
+++ b/test/e2e/docker/command_aliases.rb
@@ -5,7 +5,7 @@ require_relative '../../e2e'
 
 start_job <<-JSON
   {
-    "id": "#{$JOB_ID}",
+    "job_id": "#{$JOB_ID}",
 
     "executor": "dockercompose",
 

--- a/test/e2e/docker/container_custom_name.rb
+++ b/test/e2e/docker/container_custom_name.rb
@@ -5,7 +5,7 @@ require_relative '../../e2e'
 
 start_job <<-JSON
   {
-    "id": "#{$JOB_ID}",
+    "job_id": "#{$JOB_ID}",
 
     "executor": "dockercompose",
 

--- a/test/e2e/docker/container_env_vars.rb
+++ b/test/e2e/docker/container_env_vars.rb
@@ -5,7 +5,7 @@ require_relative '../../e2e'
 
 start_job <<-JSON
   {
-    "id": "#{$JOB_ID}",
+    "job_id": "#{$JOB_ID}",
 
     "executor": "dockercompose",
 

--- a/test/e2e/docker/container_options.rb
+++ b/test/e2e/docker/container_options.rb
@@ -5,7 +5,7 @@ require_relative '../../e2e'
 
 start_job <<-JSON
   {
-    "id": "#{$JOB_ID}",
+    "job_id": "#{$JOB_ID}",
 
     "executor": "dockercompose",
 

--- a/test/e2e/docker/docker_in_docker.rb
+++ b/test/e2e/docker/docker_in_docker.rb
@@ -5,7 +5,7 @@ require_relative '../../e2e'
 
 start_job <<-JSON
   {
-    "id": "#{$JOB_ID}",
+    "job_id": "#{$JOB_ID}",
 
     "executor": "dockercompose",
 

--- a/test/e2e/docker/docker_private_image_ecr.rb
+++ b/test/e2e/docker/docker_private_image_ecr.rb
@@ -5,7 +5,7 @@ require_relative '../../e2e'
 
 start_job <<-JSON
   {
-    "id": "#{$JOB_ID}",
+    "job_id": "#{$JOB_ID}",
 
     "executor": "dockercompose",
 

--- a/test/e2e/docker/docker_private_image_ecr_account_id.rb
+++ b/test/e2e/docker/docker_private_image_ecr_account_id.rb
@@ -7,7 +7,7 @@ aws_account_id = ENV['AWS_ACCOUNT_ID']
 
 start_job <<-JSON
   {
-    "id": "#{$JOB_ID}",
+    "job_id": "#{$JOB_ID}",
 
     "executor": "dockercompose",
 

--- a/test/e2e/docker/docker_private_image_ecr_account_id_v2.rb
+++ b/test/e2e/docker/docker_private_image_ecr_account_id_v2.rb
@@ -7,7 +7,7 @@ aws_account_id = ENV['AWS_ACCOUNT_ID']
 
 start_job <<-JSON
   {
-    "id": "#{$JOB_ID}",
+    "job_id": "#{$JOB_ID}",
 
     "executor": "dockercompose",
 

--- a/test/e2e/docker/docker_private_image_ecr_bad_creds.rb
+++ b/test/e2e/docker/docker_private_image_ecr_bad_creds.rb
@@ -5,7 +5,7 @@ require_relative '../../e2e'
 
 start_job <<-JSON
   {
-    "id": "#{$JOB_ID}",
+    "job_id": "#{$JOB_ID}",
 
     "executor": "dockercompose",
 

--- a/test/e2e/docker/docker_private_image_ecr_v2.rb
+++ b/test/e2e/docker/docker_private_image_ecr_v2.rb
@@ -7,7 +7,7 @@ aws_account_id = ENV['AWS_ACCOUNT_ID']
 
 start_job <<-JSON
   {
-    "id": "#{$JOB_ID}",
+    "job_id": "#{$JOB_ID}",
 
     "executor": "dockercompose",
 

--- a/test/e2e/docker/docker_private_image_gcr.rb
+++ b/test/e2e/docker/docker_private_image_gcr.rb
@@ -5,7 +5,7 @@ require_relative '../../e2e'
 
 start_job <<-JSON
   {
-    "id": "#{$JOB_ID}",
+    "job_id": "#{$JOB_ID}",
 
     "executor": "dockercompose",
 

--- a/test/e2e/docker/docker_private_image_gcr_bad_creds.rb
+++ b/test/e2e/docker/docker_private_image_gcr_bad_creds.rb
@@ -5,7 +5,7 @@ require_relative '../../e2e'
 
 start_job <<-JSON
   {
-    "id": "#{$JOB_ID}",
+    "job_id": "#{$JOB_ID}",
 
     "executor": "dockercompose",
 

--- a/test/e2e/docker/docker_registry_private_image.rb
+++ b/test/e2e/docker/docker_registry_private_image.rb
@@ -5,7 +5,7 @@ require_relative '../../e2e'
 
 start_job <<-JSON
   {
-    "id": "#{$JOB_ID}",
+    "job_id": "#{$JOB_ID}",
 
     "executor": "dockercompose",
 

--- a/test/e2e/docker/docker_registry_private_image_bad_creds.rb
+++ b/test/e2e/docker/docker_registry_private_image_bad_creds.rb
@@ -5,7 +5,7 @@ require_relative '../../e2e'
 
 start_job <<-JSON
   {
-    "id": "#{$JOB_ID}",
+    "job_id": "#{$JOB_ID}",
 
     "executor": "dockercompose",
 

--- a/test/e2e/docker/dockerhub_private_image.rb
+++ b/test/e2e/docker/dockerhub_private_image.rb
@@ -5,7 +5,7 @@ require_relative '../../e2e'
 
 start_job <<-JSON
   {
-    "id": "#{$JOB_ID}",
+    "job_id": "#{$JOB_ID}",
 
     "executor": "dockercompose",
 

--- a/test/e2e/docker/dockerhub_private_image_bad_creds.rb
+++ b/test/e2e/docker/dockerhub_private_image_bad_creds.rb
@@ -5,7 +5,7 @@ require_relative '../../e2e'
 
 start_job <<-JSON
   {
-    "id": "#{$JOB_ID}",
+    "job_id": "#{$JOB_ID}",
 
     "executor": "dockercompose",
 

--- a/test/e2e/docker/env_vars.rb
+++ b/test/e2e/docker/env_vars.rb
@@ -5,7 +5,7 @@ require_relative '../../e2e'
 
 start_job <<-JSON
   {
-    "id": "#{$JOB_ID}",
+    "job_id": "#{$JOB_ID}",
 
     "executor": "dockercompose",
 

--- a/test/e2e/docker/epilogue_on_fail.rb
+++ b/test/e2e/docker/epilogue_on_fail.rb
@@ -5,7 +5,7 @@ require_relative '../../e2e'
 
 start_job <<-JSON
   {
-    "id": "#{$JOB_ID}",
+    "job_id": "#{$JOB_ID}",
 
     "executor": "dockercompose",
 

--- a/test/e2e/docker/epilogue_on_pass.rb
+++ b/test/e2e/docker/epilogue_on_pass.rb
@@ -5,7 +5,7 @@ require_relative '../../e2e'
 
 start_job <<-JSON
   {
-    "id": "#{$JOB_ID}",
+    "job_id": "#{$JOB_ID}",
 
     "executor": "dockercompose",
 

--- a/test/e2e/docker/failed_job.rb
+++ b/test/e2e/docker/failed_job.rb
@@ -5,7 +5,7 @@ require_relative '../../e2e'
 
 start_job <<-JSON
   {
-    "id": "#{$JOB_ID}",
+    "job_id": "#{$JOB_ID}",
 
     "executor": "dockercompose",
 

--- a/test/e2e/docker/file_injection.rb
+++ b/test/e2e/docker/file_injection.rb
@@ -5,7 +5,7 @@ require_relative '../../e2e'
 
 start_job <<-JSON
   {
-    "id": "#{$JOB_ID}",
+    "job_id": "#{$JOB_ID}",
 
     "executor": "dockercompose",
 

--- a/test/e2e/docker/file_injection_broken_file_mode.rb
+++ b/test/e2e/docker/file_injection_broken_file_mode.rb
@@ -5,7 +5,7 @@ require_relative '../../e2e'
 
 start_job <<-JSON
   {
-    "id": "#{$JOB_ID}",
+    "job_id": "#{$JOB_ID}",
 
     "executor": "dockercompose",
 

--- a/test/e2e/docker/hello_world.rb
+++ b/test/e2e/docker/hello_world.rb
@@ -5,7 +5,7 @@ require_relative '../../e2e'
 
 start_job <<-JSON
   {
-    "id": "#{$JOB_ID}",
+    "job_id": "#{$JOB_ID}",
 
     "executor": "dockercompose",
 

--- a/test/e2e/docker/host_setup_commands.rb
+++ b/test/e2e/docker/host_setup_commands.rb
@@ -5,7 +5,7 @@ require_relative '../../e2e'
 
 start_job <<-JSON
   {
-    "id": "#{$JOB_ID}",
+    "job_id": "#{$JOB_ID}",
 
     "executor": "dockercompose",
 

--- a/test/e2e/docker/job_stopping.rb
+++ b/test/e2e/docker/job_stopping.rb
@@ -5,7 +5,7 @@ require_relative '../../e2e'
 
 start_job <<-JSON
   {
-    "id": "#{$JOB_ID}",
+    "job_id": "#{$JOB_ID}",
 
     "executor": "dockercompose",
 

--- a/test/e2e/docker/job_stopping_on_epilogue.rb
+++ b/test/e2e/docker/job_stopping_on_epilogue.rb
@@ -5,7 +5,7 @@ require_relative '../../e2e'
 
 start_job <<-JSON
   {
-    "id": "#{$JOB_ID}",
+    "job_id": "#{$JOB_ID}",
 
     "env_vars": [],
 

--- a/test/e2e/docker/multiple_containers.rb
+++ b/test/e2e/docker/multiple_containers.rb
@@ -5,7 +5,7 @@ require_relative '../../e2e'
 
 start_job <<-JSON
   {
-    "id": "#{$JOB_ID}",
+    "job_id": "#{$JOB_ID}",
 
     "executor": "dockercompose",
 

--- a/test/e2e/docker/no_bash.rb
+++ b/test/e2e/docker/no_bash.rb
@@ -14,7 +14,7 @@ require_relative '../../e2e'
 
 start_job <<-JSON
   {
-    "id": "#{$JOB_ID}",
+    "job_id": "#{$JOB_ID}",
 
     "executor": "dockercompose",
 

--- a/test/e2e/docker/non_existing_image.rb
+++ b/test/e2e/docker/non_existing_image.rb
@@ -5,7 +5,7 @@ require_relative '../../e2e'
 
 start_job <<-JSON
   {
-    "id": "#{$JOB_ID}",
+    "job_id": "#{$JOB_ID}",
 
     "executor": "dockercompose",
 

--- a/test/e2e/docker/ssh_jump_points.rb
+++ b/test/e2e/docker/ssh_jump_points.rb
@@ -37,7 +37,7 @@ x0JN8v1olTN3a1HZmo/hb3lhZS1reyfyyZr9Eg6ezHEG5ssquXIYSGfbloA2uS5B
 
 start_job <<-JSON
   {
-    "id": "#{$JOB_ID}",
+    "job_id": "#{$JOB_ID}",
 
     "ssh_public_keys": [
       "#{public_key}"

--- a/test/e2e/docker/stty_restoration.rb
+++ b/test/e2e/docker/stty_restoration.rb
@@ -5,7 +5,7 @@ require_relative '../../e2e'
 
 start_job <<-JSON
   {
-    "id": "#{$JOB_ID}",
+    "job_id": "#{$JOB_ID}",
 
     "executor": "dockercompose",
 

--- a/test/e2e/docker/unicode.rb
+++ b/test/e2e/docker/unicode.rb
@@ -8,7 +8,7 @@ require_relative '../../e2e'
 
 start_job <<-JSON
   {
-    "id": "#{$JOB_ID}",
+    "job_id": "#{$JOB_ID}",
 
     "executor": "dockercompose",
 

--- a/test/e2e/docker/unknown_command.rb
+++ b/test/e2e/docker/unknown_command.rb
@@ -5,7 +5,7 @@ require_relative '../../e2e'
 
 start_job <<-JSON
   {
-    "id": "#{$JOB_ID}",
+    "job_id": "#{$JOB_ID}",
 
     "executor": "dockercompose",
 

--- a/test/e2e/hosted/job_logs_as_artifact_always.rb
+++ b/test/e2e/hosted/job_logs_as_artifact_always.rb
@@ -8,7 +8,7 @@ require_relative '../../e2e'
 # to the job, so that it can upload the job logs as an artifact after the job is done.
 start_job <<-JSON
   {
-    "id": "#{ENV["SEMAPHORE_JOB_ID"]}",
+    "job_id": "#{ENV["SEMAPHORE_JOB_ID"]}",
     "executor": "shell",
     "env_vars": [
       { "name": "SEMAPHORE_JOB_ID", "value": "#{Base64.strict_encode64(ENV["SEMAPHORE_JOB_ID"])}" },

--- a/test/e2e/hosted/job_logs_as_artifact_default.rb
+++ b/test/e2e/hosted/job_logs_as_artifact_default.rb
@@ -8,7 +8,7 @@ require_relative '../../e2e'
 # to the job, so that it can upload the job logs as an artifact after the job is done.
 start_job <<-JSON
   {
-    "id": "#{ENV["SEMAPHORE_JOB_ID"]}",
+    "job_id": "#{ENV["SEMAPHORE_JOB_ID"]}",
     "executor": "shell",
     "env_vars": [
       { "name": "SEMAPHORE_JOB_ID", "value": "#{Base64.strict_encode64(ENV["SEMAPHORE_JOB_ID"])}" },

--- a/test/e2e/hosted/job_logs_as_artifact_never.rb
+++ b/test/e2e/hosted/job_logs_as_artifact_never.rb
@@ -8,7 +8,7 @@ require_relative '../../e2e'
 # to the job, so that it can upload the job logs as an artifact after the job is done.
 start_job <<-JSON
   {
-    "id": "#{ENV["SEMAPHORE_JOB_ID"]}",
+    "job_id": "#{ENV["SEMAPHORE_JOB_ID"]}",
     "executor": "shell",
     "env_vars": [
       { "name": "SEMAPHORE_JOB_ID", "value": "#{Base64.strict_encode64(ENV["SEMAPHORE_JOB_ID"])}" },

--- a/test/e2e/hosted/job_logs_as_artifact_not_trimmed.rb
+++ b/test/e2e/hosted/job_logs_as_artifact_not_trimmed.rb
@@ -8,7 +8,7 @@ require_relative '../../e2e'
 # to the job, so that it can upload the job logs as an artifact after the job is done.
 start_job <<-JSON
   {
-    "id": "#{ENV["SEMAPHORE_JOB_ID"]}",
+    "job_id": "#{ENV["SEMAPHORE_JOB_ID"]}",
     "executor": "shell",
     "env_vars": [
       { "name": "SEMAPHORE_JOB_ID", "value": "#{Base64.strict_encode64(ENV["SEMAPHORE_JOB_ID"])}" },

--- a/test/e2e/hosted/job_logs_as_artifact_trimmed.rb
+++ b/test/e2e/hosted/job_logs_as_artifact_trimmed.rb
@@ -8,7 +8,7 @@ require_relative '../../e2e'
 # to the job, so that it can upload the job logs as an artifact after the job is done.
 start_job <<-JSON
   {
-    "id": "#{ENV["SEMAPHORE_JOB_ID"]}",
+    "job_id": "#{ENV["SEMAPHORE_JOB_ID"]}",
     "executor": "shell",
     "env_vars": [
       { "name": "SEMAPHORE_JOB_ID", "value": "#{Base64.strict_encode64(ENV["SEMAPHORE_JOB_ID"])}" },

--- a/test/e2e/hosted/ssh_jump_points.rb
+++ b/test/e2e/hosted/ssh_jump_points.rb
@@ -37,7 +37,7 @@ x0JN8v1olTN3a1HZmo/hb3lhZS1reyfyyZr9Eg6ezHEG5ssquXIYSGfbloA2uS5B
 
 start_job <<-JSON
   {
-    "id": "#{$JOB_ID}",
+    "job_id": "#{$JOB_ID}",
 
     "ssh_public_keys": [
       "#{public_key}"

--- a/test/e2e/kubernetes/docker_compose__env-vars.rb
+++ b/test/e2e/kubernetes/docker_compose__env-vars.rb
@@ -17,7 +17,7 @@ require_relative '../../e2e'
 
 start_job <<-JSON
   {
-    "id": "#{$JOB_ID}",
+    "job_id": "#{$JOB_ID}",
 
     "executor": "dockercompose",
 

--- a/test/e2e/kubernetes/docker_compose__epilogue.rb
+++ b/test/e2e/kubernetes/docker_compose__epilogue.rb
@@ -17,7 +17,7 @@ require_relative '../../e2e'
 
 start_job <<-JSON
   {
-    "id": "#{$JOB_ID}",
+    "job_id": "#{$JOB_ID}",
     "executor": "dockercompose",
     "compose": {
       "containers": [

--- a/test/e2e/kubernetes/docker_compose__file-injection.rb
+++ b/test/e2e/kubernetes/docker_compose__file-injection.rb
@@ -17,7 +17,7 @@ require_relative '../../e2e'
 
 start_job <<-JSON
   {
-    "id": "#{$JOB_ID}",
+    "job_id": "#{$JOB_ID}",
     "executor": "dockercompose",
     "compose": {
       "containers": [

--- a/test/e2e/kubernetes/docker_compose__multiple-containers.rb
+++ b/test/e2e/kubernetes/docker_compose__multiple-containers.rb
@@ -17,7 +17,7 @@ require_relative '../../e2e'
 
 start_job <<-JSON
   {
-    "id": "#{$JOB_ID}",
+    "job_id": "#{$JOB_ID}",
 
     "executor": "dockercompose",
 

--- a/test/e2e/kubernetes/private_image_ecr_no_account_id.rb
+++ b/test/e2e/kubernetes/private_image_ecr_no_account_id.rb
@@ -17,7 +17,7 @@ require_relative '../../e2e'
 
 start_job <<-JSON
   {
-    "id": "#{$JOB_ID}",
+    "job_id": "#{$JOB_ID}",
 
     "executor": "dockercompose",
 

--- a/test/e2e/kubernetes/private_image_ecr_with_account_id.rb
+++ b/test/e2e/kubernetes/private_image_ecr_with_account_id.rb
@@ -19,7 +19,7 @@ aws_account_id = ENV['AWS_ACCOUNT_ID']
 
 start_job <<-JSON
   {
-    "id": "#{$JOB_ID}",
+    "job_id": "#{$JOB_ID}",
 
     "executor": "dockercompose",
 

--- a/test/e2e/kubernetes/private_image_gcr.rb
+++ b/test/e2e/kubernetes/private_image_gcr.rb
@@ -17,7 +17,7 @@ require_relative '../../e2e'
 
 start_job <<-JSON
   {
-    "id": "#{$JOB_ID}",
+    "job_id": "#{$JOB_ID}",
 
     "executor": "dockercompose",
 

--- a/test/e2e/kubernetes/private_image_generic.rb
+++ b/test/e2e/kubernetes/private_image_generic.rb
@@ -17,7 +17,7 @@ require_relative '../../e2e'
 
 start_job <<-JSON
   {
-    "id": "#{$JOB_ID}",
+    "job_id": "#{$JOB_ID}",
 
     "executor": "dockercompose",
 

--- a/test/e2e/kubernetes/shell__not-allowed.rb
+++ b/test/e2e/kubernetes/shell__not-allowed.rb
@@ -17,7 +17,7 @@ require_relative '../../e2e'
 
 start_job <<-JSON
   {
-    "id": "#{$JOB_ID}",
+    "job_id": "#{$JOB_ID}",
     "executor": "shell",
     "env_vars": [],
     "files": [],

--- a/test/e2e/self-hosted/docker_compose_fail_on_missing_host_files.rb
+++ b/test/e2e/self-hosted/docker_compose_fail_on_missing_host_files.rb
@@ -23,7 +23,7 @@ require_relative '../../e2e'
 
 start_job <<-JSON
   {
-    "id": "#{$JOB_ID}",
+    "job_id": "#{$JOB_ID}",
 
     "executor": "dockercompose",
 

--- a/test/e2e/self-hosted/docker_compose_host_env_vars.rb
+++ b/test/e2e/self-hosted/docker_compose_host_env_vars.rb
@@ -21,7 +21,7 @@ require_relative '../../e2e'
 
 start_job <<-JSON
   {
-    "id": "#{$JOB_ID}",
+    "job_id": "#{$JOB_ID}",
 
     "executor": "dockercompose",
 

--- a/test/e2e/self-hosted/docker_compose_host_files.rb
+++ b/test/e2e/self-hosted/docker_compose_host_files.rb
@@ -22,7 +22,7 @@ require_relative '../../e2e'
 
 start_job <<-JSON
   {
-    "id": "#{$JOB_ID}",
+    "job_id": "#{$JOB_ID}",
 
     "executor": "dockercompose",
 

--- a/test/e2e/self-hosted/docker_compose_missing_host_files.rb
+++ b/test/e2e/self-hosted/docker_compose_missing_host_files.rb
@@ -23,7 +23,7 @@ require_relative '../../e2e'
 
 start_job <<-JSON
   {
-    "id": "#{$JOB_ID}",
+    "job_id": "#{$JOB_ID}",
 
     "executor": "dockercompose",
 

--- a/test/hub_reference/app.rb
+++ b/test/hub_reference/app.rb
@@ -57,7 +57,7 @@ post "/api/v1/self_hosted_agents/sync" do
               elsif $jobs.size > 0
                 job = $jobs.shift
 
-                {"action" => "run-job", "job_id" => job["id"]}
+                {"action" => "run-job", "job_id" => job["job_id"]}
               else
                 {"action" => "continue"}
               end
@@ -140,13 +140,13 @@ end
 
 post "/private/schedule_job" do
   job = JSON.parse(@json_request)
-  puts "[PRIVATE] Scheduling job #{job["id"]}"
+  puts "[PRIVATE] Scheduling job #{job["job_id"]}"
 
-  puts "Scheduled job #{job["id"]}"
+  puts "Scheduled job #{job["job_id"]}"
 
   $jobs << job
-  $payloads[job["id"]] = job
-  $job_states[job["id"]] = "running"
+  $payloads[job["job_id"]] = job
+  $job_states[job["job_id"]] = "running"
 end
 
 post "/private/schedule_stop/:id" do

--- a/test/support/hub.go
+++ b/test/support/hub.go
@@ -166,7 +166,7 @@ func (m *HubMockServer) handleSyncRequest(w http.ResponseWriter, r *http.Request
 
 		if m.JobRequest != nil {
 			syncResponse.Action = selfhostedapi.AgentActionRunJob
-			syncResponse.JobID = m.JobRequest.ID
+			syncResponse.JobID = m.JobRequest.JobID
 		}
 
 	case selfhostedapi.AgentStateRunningJob:
@@ -176,13 +176,13 @@ func (m *HubMockServer) handleSyncRequest(w http.ResponseWriter, r *http.Request
 			gracePeriodEnd := time.Unix(request.InterruptedAt, 0).Add(time.Duration(m.RegisterRequest.InterruptionGracePeriod) * time.Second)
 			if time.Now().After(gracePeriodEnd) {
 				syncResponse.Action = selfhostedapi.AgentActionStopJob
-				syncResponse.JobID = m.JobRequest.ID
+				syncResponse.JobID = m.JobRequest.JobID
 			}
 		}
 
 		if m.ShouldShutdown {
 			syncResponse.Action = selfhostedapi.AgentActionStopJob
-			syncResponse.JobID = m.JobRequest.ID
+			syncResponse.JobID = m.JobRequest.JobID
 		}
 
 	case selfhostedapi.AgentStateFinishedJob:


### PR DESCRIPTION
Currently, we use a random name for the pod created for the job. We should use the actual Semaphore job ID.

### Unrelated changes

Added a `Dockerfile.dev` and a `make docker.build.dev` to help develop and test agents locally.