### PR TITLE
fix: POST /jobs race condition

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -2,8 +2,8 @@ version: v1.0
 name: Agent
 agent:
   machine:
-    type: e1-standard-2
-    os_image: ubuntu1804
+    type: e2-standard-2
+    os_image: ubuntu2004
 
 execution_time_limit:
   minutes: 15

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -2,8 +2,8 @@ version: v1.0
 name: Agent
 agent:
   machine:
-    type: e2-standard-2
-    os_image: ubuntu2004
+    type: e1-standard-2
+    os_image: ubuntu1804
 
 execution_time_limit:
   minutes: 15

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -24,7 +24,6 @@ import (
 )
 
 type Server struct {
-	State      string
 	Logfile    io.Writer
 	ActiveJob  *jobs.Job
 	router     *mux.Router
@@ -59,7 +58,6 @@ func NewServer(config ServerConfig) *Server {
 
 	server := &Server{
 		Config:     config,
-		State:      ServerStateWaitingForJob,
 		Logfile:    config.LogFile,
 		router:     router,
 		HTTPClient: config.HTTPClient,
@@ -113,7 +111,12 @@ func (s *Server) Status(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(200)
 	m := make(map[string]interface{})
 
-	m["state"] = s.State
+	state := ServerStateWaitingForJob
+	if s.ActiveJob != nil {
+		state = ServerStateJobReceived
+	}
+
+	m["state"] = state
 	m["version"] = s.Config.Version
 
 	jsonString, _ := json.Marshal(m)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -208,7 +208,7 @@ func (s *Server) Run(w http.ResponseWriter, r *http.Request) {
 
 	// If there's an active job already, we check if the IDs match.
 	// If they do, we return a 200, but don't do anything (idempotency).
-	// If they don't, we return a 422, since only one job should be return at a time.
+	// If they don't, we return a 422, since only one job should be run at a time.
 	if s.ActiveJob != nil {
 		if s.ActiveJob.Request.JobID == request.JobID {
 			log.Infof("Job %s is already running - no need to run again", s.ActiveJob.Request.JobID)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -204,18 +204,18 @@ func (s *Server) Run(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// If there's an active job already, we check if the IDs match.
-	// If they do, we return a 200, but don't do anything.
+	// If they do, we return a 200, but don't do anything (idempotency).
 	// If they don't, we return a 422, since only one job should be return at a time.
 	if s.ActiveJob != nil {
 		if s.ActiveJob.Request.JobID == request.JobID {
 			log.Infof("Job %s is already running - no need to run again", s.ActiveJob.Request.JobID)
-			fmt.Fprint(w, `{"message": "ok"}`)
+			fmt.Fprint(w, `{"message": "job is already running"}`)
 			return
 		}
 
 		log.Warnf("Another job %s is already running - rejecting %s", s.ActiveJob.Request.JobID, request.JobID)
 		w.WriteHeader(422)
-		fmt.Fprintf(w, `{"message": "a job is already running"}`)
+		fmt.Fprintf(w, `{"message": "another job is already running"}`)
 		return
 	}
 

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -30,7 +30,7 @@ func Test__RunJobDoesNotAcceptMultipleJobs(t *testing.T) {
 	// Run a bunch of requests concurrently,
 	// with a different job ID for each request,
 	// keeping track of their responses.
-	var totalReq int = 20
+	var totalReq = 20
 	var wg sync.WaitGroup
 	codes := make([]int, totalReq)
 	for i := 0; i < totalReq; i++ {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -1,0 +1,92 @@
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v4"
+	"github.com/semaphoreci/agent/pkg/api"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test__RunJobDoesNotAcceptMultipleJobs(t *testing.T) {
+	dummyKey := "dummykey"
+	testServer := NewServer(ServerConfig{
+		HTTPClient: http.DefaultClient,
+		JWTSecret:  []byte(dummyKey),
+	})
+
+	token, err := generateToken(dummyKey)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	// Run a bunch of requests concurrently,
+	// with a different job ID for each request,
+	// keeping track of their responses.
+	var totalReq int = 20
+	var wg sync.WaitGroup
+	codes := make([]int, totalReq)
+	for i := 0; i < totalReq; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			codes[i] = makeRequest(t, testServer, token, i)
+		}(i)
+	}
+
+	wg.Wait()
+
+	// Assert that only 1 request got a 200, and everything else got a 422.
+	assert.Equal(t, 1, countCodes(codes, http.StatusOK))
+	assert.Equal(t, totalReq-1, countCodes(codes, http.StatusUnprocessableEntity))
+}
+
+func makeRequest(t *testing.T, testServer *Server, token string, i int) int {
+	request := api.JobRequest{
+		JobID: fmt.Sprintf("job-%d", i),
+		Callbacks: api.Callbacks{
+			Finished:         "https://httpbin.org/status/200",
+			TeardownFinished: "https://httpbin.org/status/200",
+		},
+	}
+
+	body, err := json.Marshal(&request)
+	if !assert.NoError(t, err) {
+		return -1
+	}
+
+	req, _ := http.NewRequest("POST", "/jobs", bytes.NewReader(body))
+	req.Header.Add("Authorization", "Token "+token)
+	rr := httptest.NewRecorder()
+	testServer.router.ServeHTTP(rr, req)
+	return rr.Code
+}
+
+func countCodes(codes []int, code int) int {
+	count := 0
+	for _, c := range codes {
+		if c == code {
+			count++
+		}
+	}
+
+	return count
+}
+
+func generateToken(key string) (string, error) {
+	now := time.Now()
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"iat": now.Unix(),
+		"nbf": now.Unix(),
+		"exp": now.Add(time.Hour).Unix(),
+	})
+
+	return token.SignedString([]byte(key))
+}

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -48,7 +48,7 @@ func Test__RunJobDoesNotAcceptMultipleJobs(t *testing.T) {
 
 	wg.Wait()
 
-	// Assert that only 1 request got a 200, and everything else got a 422.
+	// Assert that only 1 request gets a 200, and all the other ones get a 422.
 	assert.Equal(t, 1, countCodes(codes, http.StatusOK))
 	assert.Equal(t, totalReq-1, countCodes(codes, http.StatusUnprocessableEntity))
 }
@@ -78,7 +78,7 @@ func Test__RunJobAcceptsSameJobAgain(t *testing.T) {
 	}
 
 	// Run a bunch of requests concurrently,
-	// with a the same job ID, keeping track of their responses.
+	// with the same job ID, keeping track of their responses.
 	var totalReq = 20
 	var wg sync.WaitGroup
 	codes := make([]int, totalReq)
@@ -101,9 +101,9 @@ func Test__RunJobAcceptsSameJobAgain(t *testing.T) {
 
 	wg.Wait()
 
-	// Assert that only all request got a 200,
+	// Assert that all requests get a 200,
 	// but only one of them, receive a "ok" message.
-	// The other ones receives a "job is already running" one.
+	// The other ones receives a "job is already running" message.
 	assert.Equal(t, totalReq, countCodes(codes, http.StatusOK))
 	assert.Equal(t, 1, countBodies(bodies, "ok"))
 	assert.Equal(t, totalReq-1, countBodies(bodies, "job is already running"))

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -20,6 +20,10 @@ func Test__RunJobDoesNotAcceptMultipleJobs(t *testing.T) {
 	testServer := NewServer(ServerConfig{
 		HTTPClient: http.DefaultClient,
 		JWTSecret:  []byte(dummyKey),
+
+		// We intentionally make our server slower
+		// to make these tests more reliable.
+		BeforeRunJobFn: func() { time.Sleep(100 * time.Millisecond) },
 	})
 
 	token, err := generateToken(dummyKey)

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -41,7 +41,8 @@ func Test__RunJobDoesNotAcceptMultipleJobs(t *testing.T) {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
-			codes[i] = makeRequest(t, testServer, token, i)
+			code, _ := makeRequest(t, testServer, nil, token, i)
+			codes[i] = code
 		}(i)
 	}
 
@@ -52,31 +53,101 @@ func Test__RunJobDoesNotAcceptMultipleJobs(t *testing.T) {
 	assert.Equal(t, totalReq-1, countCodes(codes, http.StatusUnprocessableEntity))
 }
 
-func makeRequest(t *testing.T, testServer *Server, token string, i int) int {
-	request := api.JobRequest{
-		JobID: fmt.Sprintf("job-%d", i),
+func Test__RunJobAcceptsSameJobAgain(t *testing.T) {
+	dummyKey := "dummykey"
+	testServer := NewServer(ServerConfig{
+		HTTPClient: http.DefaultClient,
+		JWTSecret:  []byte(dummyKey),
+
+		// We intentionally make our server slower
+		// to make these tests more reliable.
+		BeforeRunJobFn: func() { time.Sleep(100 * time.Millisecond) },
+	})
+
+	request := &api.JobRequest{
+		JobID: "same-job-id",
 		Callbacks: api.Callbacks{
 			Finished:         "https://httpbin.org/status/200",
 			TeardownFinished: "https://httpbin.org/status/200",
 		},
 	}
 
-	body, err := json.Marshal(&request)
+	token, err := generateToken(dummyKey)
 	if !assert.NoError(t, err) {
-		return -1
+		return
+	}
+
+	// Run a bunch of requests concurrently,
+	// with a the same job ID, keeping track of their responses.
+	var totalReq = 20
+	var wg sync.WaitGroup
+	codes := make([]int, totalReq)
+	bodies := make([]string, totalReq)
+	for i := 0; i < totalReq; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			code, b := makeRequest(t, testServer, request, token, i)
+			body := map[string]string{}
+			err := json.Unmarshal(b.Bytes(), &body)
+			if !assert.NoError(t, err) {
+				return
+			}
+
+			codes[i] = code
+			bodies[i] = body["message"]
+		}(i)
+	}
+
+	wg.Wait()
+
+	// Assert that only all request got a 200,
+	// but only one of them, receive a "ok" message.
+	// The other ones receives a "job is already running" one.
+	assert.Equal(t, totalReq, countCodes(codes, http.StatusOK))
+	assert.Equal(t, 1, countBodies(bodies, "ok"))
+	assert.Equal(t, totalReq-1, countBodies(bodies, "job is already running"))
+}
+
+func makeRequest(t *testing.T, testServer *Server, jobReq *api.JobRequest, token string, i int) (int, *bytes.Buffer) {
+	jobRequest := jobReq
+	if jobRequest == nil {
+		jobRequest = &api.JobRequest{
+			JobID: fmt.Sprintf("job-%d", i),
+			Callbacks: api.Callbacks{
+				Finished:         "https://httpbin.org/status/200",
+				TeardownFinished: "https://httpbin.org/status/200",
+			},
+		}
+	}
+
+	body, err := json.Marshal(&jobRequest)
+	if !assert.NoError(t, err) {
+		return -1, nil
 	}
 
 	req, _ := http.NewRequest("POST", "/jobs", bytes.NewReader(body))
 	req.Header.Add("Authorization", "Token "+token)
 	rr := httptest.NewRecorder()
 	testServer.router.ServeHTTP(rr, req)
-	return rr.Code
+	return rr.Code, rr.Body
 }
 
 func countCodes(codes []int, code int) int {
 	count := 0
 	for _, c := range codes {
 		if c == code {
+			count++
+		}
+	}
+
+	return count
+}
+
+func countBodies(bodies []string, body string) int {
+	count := 0
+	for _, b := range bodies {
+		if b == body {
 			count++
 		}
 	}


### PR DESCRIPTION
The `POST /jobs` endpoint has a race condition where multiple jobs could run if the requests come simultaneously. That happens because the `s.ActiveJob` variable might not have been updated when a new request comes in. To fix that, we use a lock in that endpoint to ensure only one request is served at a time.

I also got rid of the `State` variable since we only have two states, and it's simpler only to keep track of `ActiveJob`.

### Testing

I added two new tests for the `POST /jobs` endpoint:
- The first one covers the case of simultaneous requests for different job IDs
- The second covers the case of simultaneous requests for the same job ID

