### PR TITLE
fix: restrict logs HTTP endpoint

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -70,14 +70,11 @@ func NewServer(config ServerConfig) *Server {
 
 	router.HandleFunc("/status", jwtMiddleware(server.Status)).Methods("GET")
 	router.HandleFunc("/jobs", jwtMiddleware(server.Run)).Methods("POST")
+	router.HandleFunc("/jobs/{job_id}/log", jwtMiddleware(server.JobLogs)).Methods("GET")
 
 	// The path /stop is the new standard, /jobs/terminate is here to support the legacy system.
 	router.HandleFunc("/stop", jwtMiddleware(server.Stop)).Methods("POST")
 	router.HandleFunc("/jobs/terminate", jwtMiddleware(server.Stop)).Methods("POST")
-
-	// The path /jobs/{job_id}/log is here to support the legacy systems.
-	router.HandleFunc("/job_logs", jwtMiddleware(server.JobLogs)).Methods("GET")
-	router.HandleFunc("/jobs/{job_id}/log", jwtMiddleware(server.JobLogs)).Methods("GET")
 
 	// Agent Logs
 	router.HandleFunc("/agent_logs", jwtMiddleware(server.AgentLogs)).Methods("GET")

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -15,6 +15,38 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func Test__JobLogs(t *testing.T) {
+	dummyKey := "dummykey"
+	testServer := NewServer(ServerConfig{
+		HTTPClient: http.DefaultClient,
+		JWTSecret:  []byte(dummyKey),
+	})
+
+	token, err := generateToken(dummyKey)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	t.Run("no active job -> 404", func(t *testing.T) {
+		code, _ := getLogs(t, testServer, "job-0", token)
+		assert.Equal(t, http.StatusNotFound, code)
+	})
+
+	t.Run("job running and job on request do not match -> 403", func(t *testing.T) {
+		// Start a job with ID 'job-0'
+		code, _ := postJob(t, testServer, nil, token, 0)
+		assert.Equal(t, http.StatusOK, code)
+
+		code, _ = getLogs(t, testServer, "id-not-matching", token)
+		assert.Equal(t, http.StatusForbidden, code)
+	})
+
+	t.Run("job running and job on request match -> 200", func(t *testing.T) {
+		code, _ := getLogs(t, testServer, "job-0", token)
+		assert.Equal(t, http.StatusOK, code)
+	})
+}
+
 func Test__ServerStatus(t *testing.T) {
 	dummyKey := "dummykey"
 	testServer := NewServer(ServerConfig{
@@ -143,6 +175,14 @@ func getAgentStatus(t *testing.T, testServer *Server, token string) string {
 	}
 
 	return resp["state"]
+}
+
+func getLogs(t *testing.T, testServer *Server, jobID, token string) (int, *bytes.Buffer) {
+	req, _ := http.NewRequest("GET", fmt.Sprintf("/jobs/%s/log", jobID), nil)
+	req.Header.Add("Authorization", "Token "+token)
+	rr := httptest.NewRecorder()
+	testServer.router.ServeHTTP(rr, req)
+	return rr.Code, rr.Body
 }
 
 func postJob(t *testing.T, testServer *Server, jobReq *api.JobRequest, token string, i int) (int, *bytes.Buffer) {

--- a/test/e2e/hosted/job_logs_as_artifact_always.rb
+++ b/test/e2e/hosted/job_logs_as_artifact_always.rb
@@ -4,11 +4,13 @@
 require_relative '../../e2e'
 
 # Here, we use the SEMAPHORE_JOB_ID as the job ID for this test.
+$JOB_ID = ENV["SEMAPHORE_JOB_ID"]
+
 # Additionally, we pass the artifact related environment variables
 # to the job, so that it can upload the job logs as an artifact after the job is done.
 start_job <<-JSON
   {
-    "job_id": "#{ENV["SEMAPHORE_JOB_ID"]}",
+    "job_id": "#{$JOB_ID}",
     "executor": "shell",
     "env_vars": [
       { "name": "SEMAPHORE_JOB_ID", "value": "#{Base64.strict_encode64(ENV["SEMAPHORE_JOB_ID"])}" },

--- a/test/e2e/hosted/job_logs_as_artifact_default.rb
+++ b/test/e2e/hosted/job_logs_as_artifact_default.rb
@@ -4,11 +4,13 @@
 require_relative '../../e2e'
 
 # Here, we use the SEMAPHORE_JOB_ID as the job ID for this test.
+$JOB_ID = ENV["SEMAPHORE_JOB_ID"]
+
 # Additionally, we pass the artifact related environment variables
 # to the job, so that it can upload the job logs as an artifact after the job is done.
 start_job <<-JSON
   {
-    "job_id": "#{ENV["SEMAPHORE_JOB_ID"]}",
+    "job_id": "#{$JOB_ID}",
     "executor": "shell",
     "env_vars": [
       { "name": "SEMAPHORE_JOB_ID", "value": "#{Base64.strict_encode64(ENV["SEMAPHORE_JOB_ID"])}" },

--- a/test/e2e/hosted/job_logs_as_artifact_never.rb
+++ b/test/e2e/hosted/job_logs_as_artifact_never.rb
@@ -4,11 +4,13 @@
 require_relative '../../e2e'
 
 # Here, we use the SEMAPHORE_JOB_ID as the job ID for this test.
+$JOB_ID = ENV["SEMAPHORE_JOB_ID"]
+
 # Additionally, we pass the artifact related environment variables
 # to the job, so that it can upload the job logs as an artifact after the job is done.
 start_job <<-JSON
   {
-    "job_id": "#{ENV["SEMAPHORE_JOB_ID"]}",
+    "job_id": "#{$JOB_ID}",
     "executor": "shell",
     "env_vars": [
       { "name": "SEMAPHORE_JOB_ID", "value": "#{Base64.strict_encode64(ENV["SEMAPHORE_JOB_ID"])}" },

--- a/test/e2e/hosted/job_logs_as_artifact_not_trimmed.rb
+++ b/test/e2e/hosted/job_logs_as_artifact_not_trimmed.rb
@@ -4,11 +4,13 @@
 require_relative '../../e2e'
 
 # Here, we use the SEMAPHORE_JOB_ID as the job ID for this test.
+$JOB_ID = ENV["SEMAPHORE_JOB_ID"]
+
 # Additionally, we pass the artifact related environment variables
 # to the job, so that it can upload the job logs as an artifact after the job is done.
 start_job <<-JSON
   {
-    "job_id": "#{ENV["SEMAPHORE_JOB_ID"]}",
+    "job_id": "#{$JOB_ID}",
     "executor": "shell",
     "env_vars": [
       { "name": "SEMAPHORE_JOB_ID", "value": "#{Base64.strict_encode64(ENV["SEMAPHORE_JOB_ID"])}" },

--- a/test/e2e/hosted/job_logs_as_artifact_trimmed.rb
+++ b/test/e2e/hosted/job_logs_as_artifact_trimmed.rb
@@ -4,11 +4,13 @@
 require_relative '../../e2e'
 
 # Here, we use the SEMAPHORE_JOB_ID as the job ID for this test.
+$JOB_ID = ENV["SEMAPHORE_JOB_ID"]
+
 # Additionally, we pass the artifact related environment variables
 # to the job, so that it can upload the job logs as an artifact after the job is done.
 start_job <<-JSON
   {
-    "job_id": "#{ENV["SEMAPHORE_JOB_ID"]}",
+    "job_id": "#{$JOB_ID}",
     "executor": "shell",
     "env_vars": [
       { "name": "SEMAPHORE_JOB_ID", "value": "#{Base64.strict_encode64(ENV["SEMAPHORE_JOB_ID"])}" },

--- a/test/e2e_support/api_mode.rb
+++ b/test/e2e_support/api_mode.rb
@@ -51,7 +51,7 @@ class ApiMode
 
     Timeout.timeout(60 * 2) do
       loop do
-        `curl -s -H "Authorization: Bearer #{$TOKEN}" --fail -k "https://0.0.0.0:30000/job_logs" | grep "#{cmd}"`
+        `curl -s -H "Authorization: Bearer #{$TOKEN}" --fail -k "https://0.0.0.0:30000/jobs/#{$JOB_ID}/log" | grep "#{cmd}"`
 
         if $?.exitstatus == 0
           break

--- a/test/e2e_support/api_mode.rb
+++ b/test/e2e_support/api_mode.rb
@@ -68,7 +68,7 @@ class ApiMode
 
     Timeout.timeout(60 * 4) do
       loop do
-        `curl -s -H "Authorization: Bearer #{$TOKEN}" --fail -k "https://0.0.0.0:30000/job_logs" | grep "job_finished"`
+        `curl -s -H "Authorization: Bearer #{$TOKEN}" --fail -k "https://0.0.0.0:30000/jobs/#{$JOB_ID}/log" | grep "job_finished"`
 
         if $?.exitstatus == 0
       	break


### PR DESCRIPTION
The `GET /jobs/:id/log` endpoint should restrict access to the logs only if the job ID in the path and the job ID being run match. I also removed the `GET /job_logs` since I don't see any evidence that this endpoint is being used, and it doesn't contain the job ID, so we couldn't do this validation.