### PR TITLE
fix: never log the complete job request

### DIFF
--- a/pkg/jobs/job.go
+++ b/pkg/jobs/job.go
@@ -67,8 +67,6 @@ func NewJob(request *api.JobRequest, client *http.Client) (*Job, error) {
 }
 
 func NewJobWithOptions(options *JobOptions) (*Job, error) {
-	log.Debugf("Job Request %+v", options.Request)
-
 	if options.Request.Executor == "" {
 		log.Infof("No executor specified - using %s executor", executors.ExecutorTypeShell)
 		options.Request.Executor = executors.ExecutorTypeShell


### PR DESCRIPTION
We log the complete job request when using DEBUG logs for the agent. We shouldn't do that since the job request contains sensitive information. We should log only the job ID, and now that the [job ID is properly coming in the job request](https://github.com/semaphoreci/agent/pull/204), we already log it when the job starts.