### PR TITLE
fix: improve high log throughput job speed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ test:
 .PHONY: test
 
 test.bench:
-	go test -benchmem -run=^$$ -bench=. ./pkg/shell/ -count=10
+	go test -benchmem -run=^$$ -bench . ./... -count=10
 
 build:
 	rm -rf build

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ test:
 .PHONY: test
 
 test.bench:
-	go test -benchmem -run=^$ -bench=. ./pkg/shell/ -count=10
+	go test -benchmem -run=^$$ -bench=. ./pkg/shell/ -count=10
 
 build:
 	rm -rf build

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,9 @@ test:
 	gotestsum --format short-verbose --junitfile junit-report.xml --packages="./..." -- -p 1
 .PHONY: test
 
+test.bench:
+	go test -benchmem -run=^$ -bench=. ./pkg/shell/ -count=10
+
 build:
 	rm -rf build
 	env GOOS=linux GOARCH=386 go build -o build/agent main.go

--- a/pkg/eventlogger/httpbackend.go
+++ b/pkg/eventlogger/httpbackend.go
@@ -133,7 +133,7 @@ func (l *HTTPBackend) delay() time.Duration {
 	 * we use a tighter range of 500ms - 1000ms.
 	 */
 	if l.flush {
-		delay, _ := random.DurationInRange(500, 1000)
+		delay, _ := random.DurationInRange(250, 500)
 		return *delay
 	}
 

--- a/pkg/listener/listener_test.go
+++ b/pkg/listener/listener_test.go
@@ -215,6 +215,7 @@ func Test__ShutdownHookCanSeeShutdownReason(t *testing.T) {
 		Scheme:             "http",
 		EnvVars:            []config.HostEnvVar{},
 		FileInjections:     []config.FileInjection{},
+		UploadJobLogs:      config.UploadJobLogsConditionNever,
 		AgentVersion:       "0.0.7",
 		ShutdownHookPath:   hook,
 	}
@@ -261,6 +262,7 @@ func Test__ShutdownAfterJobFinished(t *testing.T) {
 		Scheme:             "http",
 		EnvVars:            []config.HostEnvVar{},
 		FileInjections:     []config.FileInjection{},
+		UploadJobLogs:      config.UploadJobLogsConditionNever,
 		AgentVersion:       "0.0.7",
 	}
 
@@ -310,6 +312,7 @@ func Test__ShutdownAfterIdleTimeout(t *testing.T) {
 		Scheme:                     "http",
 		EnvVars:                    []config.HostEnvVar{},
 		FileInjections:             []config.FileInjection{},
+		UploadJobLogs:              config.UploadJobLogsConditionNever,
 		AgentVersion:               "0.0.7",
 	}
 
@@ -341,6 +344,7 @@ func Test__ShutdownAfterInterruption(t *testing.T) {
 		Scheme:             "http",
 		EnvVars:            []config.HostEnvVar{},
 		FileInjections:     []config.FileInjection{},
+		UploadJobLogs:      config.UploadJobLogsConditionNever,
 		AgentVersion:       "0.0.7",
 	}
 
@@ -375,6 +379,7 @@ func Test__ShutdownAfterInterruptionNoGracePeriod(t *testing.T) {
 		Scheme:             "http",
 		EnvVars:            []config.HostEnvVar{},
 		FileInjections:     []config.FileInjection{},
+		UploadJobLogs:      config.UploadJobLogsConditionNever,
 		AgentVersion:       "0.0.7",
 	}
 
@@ -433,6 +438,7 @@ func Test__ShutdownAfterInterruptionWithGracePeriod(t *testing.T) {
 		EnvVars:                 []config.HostEnvVar{},
 		FileInjections:          []config.FileInjection{},
 		AgentVersion:            "0.0.7",
+		UploadJobLogs:           config.UploadJobLogsConditionNever,
 		InterruptionGracePeriod: 30,
 	}
 
@@ -489,6 +495,7 @@ func Test__ShutdownFromUpstreamWhileWaiting(t *testing.T) {
 		Scheme:             "http",
 		EnvVars:            []config.HostEnvVar{},
 		FileInjections:     []config.FileInjection{},
+		UploadJobLogs:      config.UploadJobLogsConditionNever,
 		AgentVersion:       "0.0.7",
 	}
 
@@ -524,6 +531,7 @@ func Test__ShutdownFromUpstreamWhileRunningJob(t *testing.T) {
 		Scheme:             "http",
 		EnvVars:            []config.HostEnvVar{},
 		FileInjections:     []config.FileInjection{},
+		UploadJobLogs:      config.UploadJobLogsConditionNever,
 		AgentVersion:       "0.0.7",
 	}
 
@@ -578,6 +586,7 @@ func Test__HostEnvVarsAreExposedToJob(t *testing.T) {
 			{Name: "IMPORTANT_HOST_VAR_B", Value: "IMPORTANT_HOST_VAR_B_VALUE"},
 		},
 		FileInjections: []config.FileInjection{},
+		UploadJobLogs:  config.UploadJobLogsConditionNever,
 		AgentVersion:   "0.0.7",
 	}
 
@@ -710,6 +719,7 @@ func Test__LogTokenIsRefreshed(t *testing.T) {
 		Scheme:             "http",
 		EnvVars:            []config.HostEnvVar{},
 		FileInjections:     []config.FileInjection{},
+		UploadJobLogs:      config.UploadJobLogsConditionNever,
 		AgentVersion:       "0.0.7",
 	}
 
@@ -789,6 +799,7 @@ func Test__GetJobIsRetried(t *testing.T) {
 		Scheme:             "http",
 		EnvVars:            []config.HostEnvVar{},
 		FileInjections:     []config.FileInjection{},
+		UploadJobLogs:      config.UploadJobLogsConditionNever,
 		AgentVersion:       "0.0.7",
 	}
 
@@ -841,6 +852,7 @@ func Test__ReportsFailedToFetchJob(t *testing.T) {
 		Scheme:             "http",
 		EnvVars:            []config.HostEnvVar{},
 		FileInjections:     []config.FileInjection{},
+		UploadJobLogs:      config.UploadJobLogsConditionNever,
 		AgentVersion:       "0.0.7",
 	}
 
@@ -890,6 +902,7 @@ func Test__ReportsFailedToConstructJob(t *testing.T) {
 		Scheme:             "http",
 		EnvVars:            []config.HostEnvVar{},
 		FileInjections:     []config.FileInjection{},
+		UploadJobLogs:      config.UploadJobLogsConditionNever,
 		AgentVersion:       "0.0.7",
 	}
 

--- a/pkg/shell/process.go
+++ b/pkg/shell/process.go
@@ -346,13 +346,14 @@ func (p *Process) writeCommandToFile(cmdFilePath, command string) error {
 	return file.Close()
 }
 
+// Determines the buffer size used when reading command output from the TTY.
+// Note: the TTY read does not block until this buffer is completely filled,
+// so there's no need to use a small buffer here. Using a 2-8k one seems reasonable.
 func (p *Process) readBufferSize() int {
-	// simulating the worst kind of baud rate
-	// random in size, and possibly very short.
 	rand.Seed(time.Now().UnixNano())
 
-	min := 64
-	max := 256
+	min := 2048
+	max := 8192
 
 	// #nosec
 	return rand.Intn(max-min) + min

--- a/pkg/shell/process.go
+++ b/pkg/shell/process.go
@@ -348,12 +348,12 @@ func (p *Process) writeCommandToFile(cmdFilePath, command string) error {
 
 // Determines the buffer size used when reading command output from the TTY.
 // Note: the TTY read does not block until this buffer is completely filled,
-// so there's no need to use a small buffer here. Using a 2-8k one seems reasonable.
+// so there's no need to use a small buffer here. 1-4k proved to be a good choice.
 func (p *Process) readBufferSize() int {
 	rand.Seed(time.Now().UnixNano())
 
-	min := 2048
-	max := 8192
+	min := 1024
+	max := 4096
 
 	// #nosec
 	return rand.Intn(max-min) + min

--- a/pkg/shell/process_test.go
+++ b/pkg/shell/process_test.go
@@ -40,7 +40,7 @@ func Benchmark__CommandOutput_100K(b *testing.B) {
 }
 
 func Benchmark__CommandOutput_250K(b *testing.B) {
-	p := createProcess(b, fmt.Sprintf("for i in {0..500}; do echo '%s'; done", strings.Repeat("x", 1024)))
+	p := createProcess(b, fmt.Sprintf("for i in {0..250}; do echo '%s'; done", strings.Repeat("x", 1024)))
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		p.Run()

--- a/pkg/shell/process_test.go
+++ b/pkg/shell/process_test.go
@@ -39,6 +39,22 @@ func Benchmark__CommandOutput_100K(b *testing.B) {
 	}
 }
 
+func Benchmark__CommandOutput_250K(b *testing.B) {
+	p := createProcess(b, fmt.Sprintf("for i in {0..500}; do echo '%s'; done", strings.Repeat("x", 1024)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		p.Run()
+	}
+}
+
+func Benchmark__CommandOutput_500K(b *testing.B) {
+	p := createProcess(b, fmt.Sprintf("for i in {0..500}; do echo '%s'; done", strings.Repeat("x", 1024)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		p.Run()
+	}
+}
+
 func Benchmark__CommandOutput_1M(b *testing.B) {
 	p := createProcess(b, fmt.Sprintf("for i in {0..1000}; do echo '%s'; done", strings.Repeat("x", 1024)))
 	b.ResetTimer()


### PR DESCRIPTION
### Command execution delays

A command termination is limited by the buffer size we use to read the command output from the TTY. Currently, we use a randomly sized buffer between 64 and 256 bytes, which is too small for high throughput command outputs. This slows the command execution itself. Through experimentation, using a randomly sized buffer in the 1k-4k range proved much faster and still used a similar amount of memory.

#### Speed

I've used buffer sizes of 1-2k, 1-4k, 1-8k, 2-4k, and 2-8k. Here are the results:

```
                           │ results__master.txt │       results__branch-1-2k.txt        │
                           │       sec/op        │    sec/op      vs base                │
__CommandOutput_128Bytes-2          117.1m ±  0%   116.8m ±   0%   -0.28% (p=0.023 n=10)
__CommandOutput_1K-2                128.0m ±  0%   127.4m ±   1%   -0.49% (p=0.000 n=10)
__CommandOutput_10K-2               133.6m ±  1%   129.3m ±   1%   -3.25% (p=0.000 n=10)
__CommandOutput_100K-2               1.089 ± 35%    1.081 ±   1%        ~ (p=0.353 n=10)
__CommandOutput_250K-2               3.373 ± 62%    2.696 ±  34%        ~ (p=0.052 n=10)
__CommandOutput_500K-2              10.800 ± 33%    2.049 ± 161%  -81.03% (p=0.000 n=10)
__CommandOutput_1M-2                20.610 ± 19%    3.314 ±  36%  -83.92% (p=0.000 n=10)
geomean                              1.073         626.8m         -41.58%


                           │ results__master.txt │       results__branch-1-4k.txt        │
                           │       sec/op        │    sec/op      vs base                │
__CommandOutput_128Bytes-2          117.1m ±  0%   113.3m ±   1%   -3.24% (p=0.000 n=10)
__CommandOutput_1K-2                128.0m ±  0%   123.1m ±   1%   -3.81% (p=0.000 n=10)
__CommandOutput_10K-2               133.6m ±  1%   124.0m ±   1%   -7.19% (p=0.000 n=10)
__CommandOutput_100K-2               1.089 ± 35%    1.066 ±   0%        ~ (p=0.165 n=10)
__CommandOutput_250K-2               3.373 ± 62%    2.637 ±  47%        ~ (p=0.052 n=10)
__CommandOutput_500K-2              10.800 ± 33%    2.065 ± 138%  -80.88% (p=0.000 n=10)
__CommandOutput_1M-2                20.610 ± 19%    2.156 ±  34%  -89.54% (p=0.000 n=10)
geomean                              1.073         578.4m         -46.10%

                           │ results__master.txt │       results__branch-1-8k.txt        │
                           │       sec/op        │    sec/op      vs base                │
__CommandOutput_128Bytes-2          117.1m ±  0%   116.7m ±   2%        ~ (p=0.052 n=10)
__CommandOutput_1K-2                128.0m ±  0%   127.4m ±   0%   -0.51% (p=0.002 n=10)
__CommandOutput_10K-2               133.6m ±  1%   128.8m ±   1%   -3.63% (p=0.000 n=10)
__CommandOutput_100K-2               1.089 ± 35%    1.086 ±   0%        ~ (p=0.796 n=10)
__CommandOutput_250K-2               3.373 ± 62%    2.475 ±  44%  -26.62% (p=0.009 n=10)
__CommandOutput_500K-2              10.800 ± 33%    2.309 ± 128%  -78.62% (p=0.000 n=10)
__CommandOutput_1M-2                20.610 ± 19%    2.537 ±  35%  -87.69% (p=0.000 n=10)
geomean                              1.073         606.4m         -43.49%

                           │ results__master.txt │       results__branch-2-4k.txt       │
                           │       sec/op        │    sec/op     vs base                │
__CommandOutput_128Bytes-2          117.1m ±  0%   112.9m ±  0%   -3.60% (p=0.000 n=10)
__CommandOutput_1K-2                128.0m ±  0%   123.0m ±  0%   -3.89% (p=0.000 n=10)
__CommandOutput_10K-2               133.6m ±  1%   123.7m ±  0%   -7.40% (p=0.000 n=10)
__CommandOutput_100K-2               1.089 ± 35%    1.065 ±  1%        ~ (p=0.143 n=10)
__CommandOutput_250K-2               3.373 ± 62%    2.642 ±  0%        ~ (p=0.089 n=10)
__CommandOutput_500K-2              10.800 ± 33%    2.547 ± 72%  -76.41% (p=0.000 n=10)
__CommandOutput_1M-2                20.610 ± 19%    2.403 ± 68%  -88.34% (p=0.000 n=10)
geomean                              1.073         604.8m        -43.63%

                           │ results__master.txt │       results__branch-2-8k.txt       │
                           │       sec/op        │    sec/op     vs base                │
__CommandOutput_128Bytes-2          117.1m ±  0%   112.7m ±  0%   -3.74% (p=0.000 n=10)
__CommandOutput_1K-2                128.0m ±  0%   123.0m ±  0%   -3.89% (p=0.000 n=10)
__CommandOutput_10K-2               133.6m ±  1%   127.3m ±  3%   -4.71% (p=0.000 n=10)
__CommandOutput_100K-2               1.089 ± 35%    1.084 ±  2%        ~ (p=0.684 n=10)
__CommandOutput_250K-2               3.373 ± 62%    2.667 ± 39%  -20.94% (p=0.029 n=10)
__CommandOutput_500K-2              10.800 ± 33%    3.666 ± 27%  -66.06% (p=0.000 n=10)
__CommandOutput_1M-2                20.610 ± 19%    1.952 ± 92%  -90.53% (p=0.000 n=10)
geomean                              1.073         623.2m        -41.92%
```

Conclusion: above 1-4k, things don't get faster, so we'd just be allocating more memory than needed. 1-4k is the champion.

#### Memory allocation

```
                           │ results__master.txt │       results__branch-1-2k.txt        │
                           │        B/op         │     B/op       vs base                │
__CommandOutput_128Bytes-2         10.53Ki ± 21%   13.42Ki ± 33%  +27.38% (p=0.023 n=10)
__CommandOutput_1K-2               20.93Ki ± 12%   19.91Ki ± 25%        ~ (p=0.579 n=10)
__CommandOutput_10K-2              149.3Ki ±  4%   140.1Ki ±  4%   -6.18% (p=0.000 n=10)
__CommandOutput_100K-2             1.314Mi ±  7%   1.311Mi ±  5%        ~ (p=0.529 n=10)
__CommandOutput_250K-2             2.975Mi ±  1%   3.158Mi ±  3%   +6.13% (p=0.000 n=10)
__CommandOutput_500K-2             5.831Mi ±  1%   5.861Mi ±  8%        ~ (p=1.000 n=10)
__CommandOutput_1M-2               11.52Mi ±  1%   10.79Mi ±  3%   -6.27% (p=0.000 n=10)
geomean                            514.2Ki         523.5Ki         +1.82%

                           │ results__master.txt │       results__branch-1-4k.txt        │
                           │        B/op         │     B/op       vs base                │
__CommandOutput_128Bytes-2         10.53Ki ± 21%   18.76Ki ± 16%  +78.10% (p=0.000 n=10)
__CommandOutput_1K-2               20.93Ki ± 12%   24.01Ki ± 18%        ~ (p=0.089 n=10)
__CommandOutput_10K-2              149.3Ki ±  4%   156.8Ki ± 15%        ~ (p=0.165 n=10)
__CommandOutput_100K-2             1.314Mi ±  7%   1.421Mi ± 10%        ~ (p=0.143 n=10)
__CommandOutput_250K-2             2.975Mi ±  1%   3.335Mi ±  4%  +12.09% (p=0.000 n=10)
__CommandOutput_500K-2             5.831Mi ±  1%   6.112Mi ±  9%        ~ (p=0.075 n=10)
__CommandOutput_1M-2               11.52Mi ±  1%   11.19Mi ±  3%   -2.83% (p=0.011 n=10)
geomean                            514.2Ki         590.9Ki        +14.93%

                           │ results__master.txt │        results__branch-1-8k.txt        │
                           │        B/op         │     B/op       vs base                 │
__CommandOutput_128Bytes-2         10.53Ki ± 21%   25.67Ki ± 14%  +143.70% (p=0.000 n=10)
__CommandOutput_1K-2               20.93Ki ± 12%   27.40Ki ± 15%   +30.92% (p=0.000 n=10)
__CommandOutput_10K-2              149.3Ki ±  4%   172.4Ki ± 12%   +15.47% (p=0.004 n=10)
__CommandOutput_100K-2             1.314Mi ±  7%   1.666Mi ± 11%   +26.80% (p=0.000 n=10)
__CommandOutput_250K-2             2.975Mi ±  1%   3.882Mi ± 12%   +30.48% (p=0.000 n=10)
__CommandOutput_500K-2             5.831Mi ±  1%   7.035Mi ± 13%   +20.64% (p=0.000 n=10)
__CommandOutput_1M-2               11.52Mi ±  1%   12.20Mi ± 12%    +5.90% (p=0.023 n=10)
geomean                            514.2Ki         689.4Ki         +34.07%

                           │ results__master.txt │        results__branch-2-4k.txt        │
                           │        B/op         │     B/op       vs base                 │
__CommandOutput_128Bytes-2         10.53Ki ± 21%   21.21Ki ± 23%  +101.34% (p=0.000 n=10)
__CommandOutput_1K-2               20.93Ki ± 12%   26.19Ki ± 24%   +25.16% (p=0.019 n=10)
__CommandOutput_10K-2              149.3Ki ±  4%   164.0Ki ± 19%         ~ (p=0.247 n=10)
__CommandOutput_100K-2             1.314Mi ±  7%   1.475Mi ± 20%         ~ (p=0.165 n=10)
__CommandOutput_250K-2             2.975Mi ±  1%   3.448Mi ±  2%   +15.90% (p=0.000 n=10)
__CommandOutput_500K-2             5.831Mi ±  1%   6.712Mi ± 15%   +15.10% (p=0.029 n=10)
__CommandOutput_1M-2               11.52Mi ±  1%   11.60Mi ±  2%         ~ (p=0.529 n=10)
geomean                            514.2Ki         630.6Ki         +22.65%

                           │ results__master.txt │        results__branch-2-8k.txt        │
                           │        B/op         │     B/op       vs base                 │
__CommandOutput_128Bytes-2         10.53Ki ± 21%   24.06Ki ± 24%  +128.47% (p=0.000 n=10)
__CommandOutput_1K-2               20.93Ki ± 12%   31.94Ki ± 35%   +52.62% (p=0.000 n=10)
__CommandOutput_10K-2              149.3Ki ±  4%   175.8Ki ± 22%   +17.69% (p=0.001 n=10)
__CommandOutput_100K-2             1.314Mi ±  7%   1.637Mi ± 15%   +24.62% (p=0.000 n=10)
__CommandOutput_250K-2             2.975Mi ±  1%   4.169Mi ± 10%   +40.12% (p=0.000 n=10)
__CommandOutput_500K-2             5.831Mi ±  1%   7.516Mi ±  4%   +28.88% (p=0.000 n=10)
__CommandOutput_1M-2               11.52Mi ±  1%   12.22Mi ±  6%    +6.11% (p=0.007 n=10)
geomean                            514.2Ki         712.4Ki         +38.55%
```

Conclusion: these numbers enforce the idea of using a 1-4k-sized buffer since memory allocation stays the same.

### Self-hosted job termination delays

Self-hosted job termination is limited by how fast we can flush the job logs to the control plane. When flushing logs (job commands are finished, but we haven't sent all the output to the control plane yet), we already use a smaller request delay (500-1000ms) than the regular one (1500-3000ms). This pull request decreases that flushing delay a bit more - 250-500ms.

### Other changes

Added two more benchmarks, and updated the `pkg/listener/listener_test.go` tests to use `config.UploadJobLogsConditionNever` (not what those tests need to assert).