### PR TITLE
fix: remove docker resources explicitly

### DIFF
--- a/pkg/executors/docker_compose_executor.go
+++ b/pkg/executors/docker_compose_executor.go
@@ -741,17 +741,27 @@ func (e *DockerComposeExecutor) Stop() int {
 		err := e.Shell.Close()
 		if err != nil {
 			log.Errorf("Process killing procedure returned an error %+v\n", err)
-
-			return 0
 		}
 	}
 
-	log.Debug("Process killing finished without errors")
-
-	return 0
+	return e.Cleanup()
 }
 
 func (e *DockerComposeExecutor) Cleanup() int {
+	log.Info("Cleaning up docker resources")
+	cmd := exec.Command(
+		"docker-compose",
+		"-f",
+		e.dockerComposeManifestPath,
+		"down",
+		"--remove-orphans",
+	)
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		log.Errorf("Error removing docker resources: %v - %s", err, output)
+	}
+
 	return 0
 }
 

--- a/pkg/executors/docker_compose_executor.go
+++ b/pkg/executors/docker_compose_executor.go
@@ -749,6 +749,8 @@ func (e *DockerComposeExecutor) Stop() int {
 
 func (e *DockerComposeExecutor) Cleanup() int {
 	log.Info("Cleaning up docker resources")
+
+	// #nosec
 	cmd := exec.Command(
 		"docker-compose",
 		"-f",

--- a/pkg/shell/shell.go
+++ b/pkg/shell/shell.go
@@ -207,6 +207,10 @@ func (s *Shell) silencePromptAndDisablePS1() error {
 			return fmt.Errorf(text)
 		}
 
+		if strings.Contains(text, "The container name \"/main\" is already in use") {
+			return fmt.Errorf(text)
+		}
+
 		if !strings.Contains(text, "echo") && strings.Contains(text, everythingIsReadyMark) {
 			break
 		}


### PR DESCRIPTION
This pull request fixes two issues:
- Proper cleanup of docker resources to ensure reentrant agents work
- Shell startup for docker-compose executor should fail if a container named `main` already exists.

### Cleaning up resources

The `--rm` argument of `docker-compose run` does not always work. We should take a more explicit approach and run a `docker-compose down` when the job is finished to ensure everything is deleted.

### Failing shell startup

Even though the `docker-compose run` command fails due to an existing container named `main`, the "Starting the docker image..." command does not fail:

```
Oct 11 13:54:48.969 O6XvpqiMx3P2IIG98uZn : (tty) Error response from daemon: Conflict. The container name "/main" is already in use by container "4e19b104d641342b07cbd64684181600c411bbe6b72b3b8d620834730dfb557d". You have to remove (or rename) that container to be able to reuse that name.
Oct 11 13:54:48.979 O6XvpqiMx3P2IIG98uZn : Shell closed with exit status 1. Closing associated TTY
Oct 11 13:54:48.980 O6XvpqiMx3P2IIG98uZn : Publishing an exit signal: exit status 1
Oct 11 13:54:48.980 O6XvpqiMx3P2IIG98uZn : {"event":"cmd_finished","timestamp":1697032488,"directive":"Starting the docker image...","exit_code":0,"started_at":1697032488,"finished_at":1697032488}
```

Now, we fail the shell startup command, if that error is encountered.