### PR TITLE
fix(build): do not use GH binary on docker.build

### DIFF
--- a/Dockerfile.self_hosted
+++ b/Dockerfile.self_hosted
@@ -1,7 +1,5 @@
 FROM ubuntu:20.04
 
-ARG AGENT_VERSION
-
 ARG USERNAME=semaphore
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
@@ -18,13 +16,9 @@ RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/s
 RUN install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
 
 # Install Semaphore agent
-RUN mkdir -p /opt/semaphore && \
-  curl -L https://github.com/semaphoreci/agent/releases/download/${AGENT_VERSION}/agent_Linux_x86_64.tar.gz -o /opt/semaphore/agent.tar.gz && \
-  tar -xf /opt/semaphore/agent.tar.gz -C /opt/semaphore && \
-  rm /opt/semaphore/agent.tar.gz && \
-  rm /opt/semaphore/README.md && \
-  rm /opt/semaphore/install.sh && \
-  chown ${USER_UID}:${USER_GID} /opt/semaphore
+RUN mkdir -p /opt/semaphore
+ADD build/agent /opt/semaphore/agent
+RUN chown ${USER_UID}:${USER_GID} /opt/semaphore
 
 USER $USERNAME
 WORKDIR /home/semaphore

--- a/Dockerfile.self_hosted
+++ b/Dockerfile.self_hosted
@@ -17,7 +17,7 @@ RUN install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
 
 # Install Semaphore agent
 RUN mkdir -p /opt/semaphore
-ADD build/agent /opt/semaphore/agent
+COPY build/agent /opt/semaphore/agent
 RUN chown ${USER_UID}:${USER_GID} /opt/semaphore
 
 USER $USERNAME

--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ docker.build.dev:
 #
 docker.build:
 	env GOOS=linux GOARCH=amd64 go build -o build/agent main.go
-	docker build --build-arg -f Dockerfile.self_hosted -t semaphoreci/agent:latest .
+	docker build -f Dockerfile.self_hosted -t semaphoreci/agent:latest .
 
 docker.push:
 	docker tag semaphoreci/agent:latest semaphoreci/agent:$(LATEST_VERSION)

--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,8 @@ docker.build.dev:
 # Docker Release
 #
 docker.build:
-	docker build --build-arg AGENT_VERSION=$(LATEST_VERSION) -f Dockerfile.self_hosted -t semaphoreci/agent:latest .
+	env GOOS=linux GOARCH=amd64 go build -o build/agent main.go
+	docker build --build-arg -f Dockerfile.self_hosted -t semaphoreci/agent:latest .
 
 docker.push:
 	docker tag semaphoreci/agent:latest semaphoreci/agent:$(LATEST_VERSION)

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,10 @@ AGENT_SSH_PORT_IN_TESTS=2222
 SECURITY_TOOLBOX_BRANCH ?= master
 SECURITY_TOOLBOX_TMP_DIR ?= /tmp/security-toolbox
 
-LATEST_VERSION=$(shell git tag | sort --version-sort | tail -n 1)
+AGENT_VERSION=dev
+ifneq ($(SEMAPHORE_GIT_TAG_NAME),)
+	AGENT_VERSION=$(SEMAPHORE_GIT_TAG_NAME)
+endif
 
 check.prepare:
 	rm -rf $(SECURITY_TOOLBOX_TMP_DIR)
@@ -90,7 +93,7 @@ docker.build.dev:
 # Docker Release
 #
 docker.build:
-	env GOOS=linux GOARCH=amd64 go build -o build/agent main.go
+	env GOOS=linux GOARCH=amd64 go build -ldflags='-s -w -X "main.VERSION=$(AGENT_VERSION)"' -o build/agent main.go
 	docker build -f Dockerfile.self_hosted -t semaphoreci/agent:latest .
 
 docker.push:

--- a/Makefile
+++ b/Makefile
@@ -97,8 +97,8 @@ docker.build:
 	docker build -f Dockerfile.self_hosted -t semaphoreci/agent:latest .
 
 docker.push:
-	docker tag semaphoreci/agent:latest semaphoreci/agent:$(LATEST_VERSION)
-	docker push semaphoreci/agent:$(LATEST_VERSION)
+	docker tag semaphoreci/agent:latest semaphoreci/agent:$(AGENT_VERSION)
+	docker push semaphoreci/agent:$(AGENT_VERSION)
 	docker push semaphoreci/agent:latest
 
 release.major:


### PR DESCRIPTION
To build the `Dockerfile.self_hosted` image, we are using the binary from GH from the latest tag. The problem is on a tag build, this will fail since the latest tag will not have a release yet. We should build the binary and use it, instead of relying on the GH one.