### PR TITLE
fix: use docker compose v2 when available

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -155,6 +155,7 @@ blocks:
                 - check_dev_kvm
                 - host_setup_commands
                 - multiple_containers
+                - compose_v1
 
   - name: "Hosted E2E tests"
     dependencies: []

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -3,10 +3,10 @@ FROM python:3
 RUN apt-get update && \
   apt-get install curl -y && \
   curl -sSL https://get.docker.com/ | sh && \
-  apt-get install -y ssh && \
+  apt-get install -y ssh docker-compose-plugin && \
   # pin pyyaml to 5.3.1 until https://github.com/yaml/pyyaml/issues/724 is fixed
   pip install pyyaml==5.3.1 && \
-  pip install docker-compose awscli
+  pip install awscli
 
 # By default, sshd runs on port 22, we need it to run on port 2222
 RUN sed -i 's/#Port 22/Port 2222/g' /etc/ssh/sshd_config

--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -114,11 +114,7 @@ func configServerURL(strategy string, credentials api.ImagePullCredentials) (str
 	}
 }
 
-func HasDockerComposeV2() bool {
-	return exec.Command("docker", "compose", "version").Run() == nil
-}
-
-func DockerComposeV2Version() (string, error) {
+func DockerComposePluginVersion() (string, error) {
 	output, err := exec.Command("docker", "compose", "version").Output()
 	if err != nil {
 		return "", err
@@ -132,7 +128,9 @@ func DockerComposeV2Version() (string, error) {
 	return match[1], nil
 }
 
-func DockerComposeV1Version() (string, error) {
+// NOTE: this doesn't necessarily points to a docker compose v1 installation.
+// Sometimes, 'docker-compose' is an alias to the docker compose v2 plugin.
+func DockerComposeCLIVersion() (string, error) {
 	output, err := exec.Command("docker-compose", "--version").Output()
 	if err != nil {
 		return "", err
@@ -147,9 +145,10 @@ func DockerComposeV1Version() (string, error) {
 }
 
 func DockerComposeVersion() (string, error) {
-	if HasDockerComposeV2() {
-		return DockerComposeV2Version()
+	version, err := DockerComposePluginVersion()
+	if err == nil {
+		return version, nil
 	}
 
-	return DockerComposeV1Version()
+	return DockerComposeCLIVersion()
 }

--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -3,6 +3,7 @@ package docker
 import (
 	"encoding/base64"
 	"fmt"
+	"os/exec"
 
 	"github.com/semaphoreci/agent/pkg/api"
 	"github.com/semaphoreci/agent/pkg/aws"
@@ -106,4 +107,8 @@ func configServerURL(strategy string, credentials api.ImagePullCredentials) (str
 	default:
 		return "", fmt.Errorf("%s not supported", strategy)
 	}
+}
+
+func HasDockerComposeV2Plugin() bool {
+	return exec.Command("docker", "compose", "version").Run() == nil
 }

--- a/pkg/docker/docker_test.go
+++ b/pkg/docker/docker_test.go
@@ -8,6 +8,16 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func Test__DockerComposeVersion(t *testing.T) {
+	v1Version, err := DockerComposeV1Version()
+	assert.NoError(t, err)
+	assert.Contains(t, v1Version, "v1")
+
+	v2Version, err := DockerComposeV2Version()
+	assert.NoError(t, err)
+	assert.Contains(t, v2Version, "v2")
+}
+
 func Test__NewDockerConfig(t *testing.T) {
 	t.Run("no credentials", func(t *testing.T) {
 		_, err := NewDockerConfig([]api.ImagePullCredentials{})

--- a/pkg/docker/docker_test.go
+++ b/pkg/docker/docker_test.go
@@ -2,6 +2,7 @@ package docker
 
 import (
 	"encoding/base64"
+	"runtime"
 	"testing"
 
 	"github.com/semaphoreci/agent/pkg/api"
@@ -9,6 +10,10 @@ import (
 )
 
 func Test__DockerComposeVersion(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip()
+	}
+
 	v1Version, err := DockerComposeCLIVersion()
 	assert.NoError(t, err)
 	assert.Contains(t, v1Version, "1.")

--- a/pkg/docker/docker_test.go
+++ b/pkg/docker/docker_test.go
@@ -9,13 +9,13 @@ import (
 )
 
 func Test__DockerComposeVersion(t *testing.T) {
-	v1Version, err := DockerComposeV1Version()
+	v1Version, err := DockerComposeCLIVersion()
 	assert.NoError(t, err)
-	assert.Contains(t, v1Version, "v1")
+	assert.Contains(t, v1Version, "1.")
 
-	v2Version, err := DockerComposeV2Version()
+	v2Version, err := DockerComposePluginVersion()
 	assert.NoError(t, err)
-	assert.Contains(t, v2Version, "v2")
+	assert.Contains(t, v2Version, "v2.")
 }
 
 func Test__NewDockerConfig(t *testing.T) {

--- a/pkg/executors/docker_compose_executor.go
+++ b/pkg/executors/docker_compose_executor.go
@@ -30,6 +30,7 @@ type DockerComposeExecutor struct {
 	tmpDirectory              string
 	dockerConfiguration       api.Compose
 	dockerComposeManifestPath string
+	dockerComposeVersion      string
 	mainContainerName         string
 	exposeKvmDevice           bool
 	fileInjections            []config.FileInjection
@@ -71,6 +72,7 @@ func (e *DockerComposeExecutor) Prepare() int {
 	}
 
 	log.Infof("Using Docker Compose version %s", version)
+	e.dockerComposeVersion = version
 
 	err = os.MkdirAll(e.tmpDirectory, os.ModePerm)
 	if err != nil {
@@ -203,7 +205,7 @@ func (e *DockerComposeExecutor) Start() int {
 }
 
 func (e *DockerComposeExecutor) composeExecutableAndArgs() (string, []string) {
-	if docker.HasDockerComposeV2() {
+	if strings.HasPrefix(e.dockerComposeVersion, "v2") {
 		return "docker", []string{"compose"}
 	}
 

--- a/pkg/executors/docker_compose_executor.go
+++ b/pkg/executors/docker_compose_executor.go
@@ -65,16 +65,7 @@ func (e *DockerComposeExecutor) Prepare() int {
 		return 1
 	}
 
-	version, err := docker.DockerComposeVersion()
-	if err != nil {
-		log.Errorf("Error finding docker compose: %v", err)
-		return 1
-	}
-
-	log.Infof("Using Docker Compose version %s", version)
-	e.dockerComposeVersion = version
-
-	err = os.MkdirAll(e.tmpDirectory, os.ModePerm)
+	err := os.MkdirAll(e.tmpDirectory, os.ModePerm)
 	if err != nil {
 		return 1
 	}
@@ -83,6 +74,15 @@ func (e *DockerComposeExecutor) Prepare() int {
 	if err != nil {
 		return 1
 	}
+
+	version, err := docker.DockerComposeVersion()
+	if err != nil {
+		log.Errorf("Error finding docker compose: %v", err)
+		return 1
+	}
+
+	log.Infof("Using Docker Compose version %s", version)
+	e.dockerComposeVersion = version
 
 	filesToInject, err := e.findValidFilesToInject()
 	if err != nil {

--- a/test/e2e/docker/compose_v1.rb
+++ b/test/e2e/docker/compose_v1.rb
@@ -1,0 +1,66 @@
+#!/bin/ruby
+# rubocop:disable all
+
+require_relative '../../e2e'
+
+start_job <<-JSON
+  {
+    "job_id": "#{$JOB_ID}",
+
+    "executor": "dockercompose",
+
+    "compose": {
+      "containers": [
+        {
+          "name": "main",
+          "image": "ruby:2.6"
+        }
+      ],
+      "host_setup_commands": [
+        { "directive": "apt purge -y docker-compose-plugin && rm -rf ~/.docker/cli-plugins/docker-compose" },
+        { "directive": "curl -sL 'https://github.com/docker/compose/releases/download/1.29.2/docker-compose-Linux-x86_64' -o /usr/local/bin/docker-compose" },
+        { "directive": "chmod +x /usr/local/bin/docker-compose" }
+      ]
+    },
+
+    "env_vars": [],
+
+    "files": [],
+
+    "commands": [
+      { "directive": "echo Hello World" }
+    ],
+
+    "callbacks": {
+      "finished": "#{finished_callback_url}",
+      "teardown_finished": "#{teardown_callback_url}"
+    },
+    "logger": #{$LOGGER}
+  }
+JSON
+
+wait_for_job_to_finish
+
+assert_job_log <<-LOG
+  {"event":"job_started",  "timestamp":"*"}
+  {"event":"cmd_started",  "timestamp":"*", "directive":"Pulling docker images..."}
+  *** LONG_OUTPUT ***
+  {"event":"cmd_finished", "timestamp":"*", "directive":"Pulling docker images...","event":"cmd_finished","exit_code":0,"finished_at":"*","started_at":"*","timestamp":"*"}
+
+  {"event":"cmd_started",  "timestamp":"*", "directive":"Starting the docker image..."}
+  {"event":"cmd_output",   "timestamp":"*", "output":"Starting a new bash session.\\n"}
+  {"event":"cmd_finished", "timestamp":"*", "directive":"Starting the docker image...","event":"cmd_finished","exit_code":0,"finished_at":"*","started_at":"*","timestamp":"*"}
+
+  {"event":"cmd_started",  "timestamp":"*", "directive":"Exporting environment variables"}
+  {"event":"cmd_finished", "timestamp":"*", "directive":"Exporting environment variables","exit_code":0,"finished_at":"*","started_at":"*"}
+  {"event":"cmd_started",  "timestamp":"*", "directive":"Injecting Files"}
+  {"event":"cmd_finished", "timestamp":"*", "directive":"Injecting Files","exit_code":0,"finished_at":"*","started_at":"*"}
+  {"event":"cmd_started",  "timestamp":"*", "directive":"echo Hello World"}
+  {"event":"cmd_output",   "timestamp":"*", "output":"Hello World\\n"}
+  {"event":"cmd_finished", "timestamp":"*", "directive":"echo Hello World","exit_code":0,"finished_at":"*","started_at":"*"}
+  {"event":"cmd_started",  "timestamp":"*", "directive":"Exporting environment variables"}
+  {"event":"cmd_output",   "timestamp":"*", "output":"Exporting SEMAPHORE_JOB_RESULT\\n"}
+  {"event":"cmd_finished", "timestamp":"*", "directive":"Exporting environment variables","exit_code":0,"started_at":"*","finished_at":"*"}
+
+  {"event":"job_finished", "timestamp":"*", "result":"passed"}
+LOG


### PR DESCRIPTION
### Motivation

[This issue](https://github.com/docker/docker-py/issues/3194) is making our CI fail at the moment. That made me realize the docker compose executor is not smart enough to docker compose v2, it it's available. Since docker compose v1 is deprecated and [no longer receives security updates](https://docs.docker.com/compose/migrate/), we should only use it if the docker compose v2 plugin is not available.

### Solution

On the docker compose prepare stage, we determine the docker compose version available, giving precedence to the v2 plugin, falling back to v1.

### Testing

All the E2E tests were updated to [use docker compose v2](https://semaphore.semaphoreci.com/jobs/842b0459-871d-491c-bae0-49e978386bd8#L6369), and a new E2E that [uses docker compose v1](https://semaphore.semaphoreci.com/jobs/5b9b8510-9ff3-4919-9e15-053abaef1e8e#L4902) was added.