### PR TITLE
fix: use 30s timeout on HTTP requests

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -6,7 +6,9 @@ RUN apt-get update && \
   apt-get install -y ssh && \
   # pin pyyaml to 5.3.1 until https://github.com/yaml/pyyaml/issues/724 is fixed
   pip install pyyaml==5.3.1 && \
-  pip install docker-compose awscli
+  pip install awscli && \
+  curl -sL 'https://github.com/docker/compose/releases/download/1.29.2/docker-compose-Linux-x86_64' -o /usr/local/bin/docker-compose && \
+  chmod +x /usr/local/bin/docker-compose
 
 # By default, sshd runs on port 22, we need it to run on port 2222
 RUN sed -i 's/#Port 22/Port 2222/g' /etc/ssh/sshd_config

--- a/main.go
+++ b/main.go
@@ -53,7 +53,9 @@ func main() {
 
 	action := os.Args[1]
 
-	httpClient := &http.Client{}
+	httpClient := &http.Client{
+		Timeout: 10 * time.Second,
+	}
 
 	switch action {
 	case "start":

--- a/main.go
+++ b/main.go
@@ -54,7 +54,7 @@ func main() {
 	action := os.Args[1]
 
 	httpClient := &http.Client{
-		Timeout: 10 * time.Second,
+		Timeout: 30 * time.Second,
 	}
 
 	switch action {

--- a/pkg/eventlogger/httpbackend.go
+++ b/pkg/eventlogger/httpbackend.go
@@ -61,7 +61,7 @@ func NewHTTPBackend(config HTTPBackendConfig) (*HTTPBackend, error) {
 
 	httpBackend := HTTPBackend{
 		client: &http.Client{
-			Timeout: 10 * time.Second,
+			Timeout: 30 * time.Second,
 		},
 		fileBackend: *fileBackend,
 		startFrom:   0,

--- a/pkg/eventlogger/httpbackend.go
+++ b/pkg/eventlogger/httpbackend.go
@@ -60,7 +60,9 @@ func NewHTTPBackend(config HTTPBackendConfig) (*HTTPBackend, error) {
 	}
 
 	httpBackend := HTTPBackend{
-		client:      &http.Client{},
+		client: &http.Client{
+			Timeout: 10 * time.Second,
+		},
 		fileBackend: *fileBackend,
 		startFrom:   0,
 		config:      config,


### PR DESCRIPTION
We are not currently using any HTTP timeout for our HTTP requests. We shouldn't do that. Here, we introduce a 30s timeout for all HTTP requests.