### PR TITLE
feat: register agent for specific job

### DIFF
--- a/main.go
+++ b/main.go
@@ -120,7 +120,7 @@ func RunListener(httpClient *http.Client, logfile io.Writer) {
 	_ = pflag.String(config.PreJobHookPath, "", "Pre-job hook path")
 	_ = pflag.String(config.PostJobHookPath, "", "Post-job hook path")
 	_ = pflag.Bool(config.DisconnectAfterJob, false, "Disconnect after job")
-	_ = pflag.String(config.RunJob, "", "Request a specific job to run")
+	_ = pflag.String(config.JobID, "", "Request a specific job to run")
 	_ = pflag.Int(config.DisconnectAfterIdleTimeout, 0, "Disconnect after idle timeout, in seconds")
 	_ = pflag.Int(config.InterruptionGracePeriod, 0, "The grace period, in seconds, to wait after receiving an interrupt signal")
 	_ = pflag.StringSlice(config.EnvVars, []string{}, "Export environment variables in jobs")
@@ -194,7 +194,7 @@ func RunListener(httpClient *http.Client, logfile io.Writer) {
 		PreJobHookPath:                   viper.GetString(config.PreJobHookPath),
 		PostJobHookPath:                  viper.GetString(config.PostJobHookPath),
 		DisconnectAfterJob:               viper.GetBool(config.DisconnectAfterJob),
-		RunJob:                           viper.GetString(config.RunJob),
+		JobID:                            viper.GetString(config.JobID),
 		DisconnectAfterIdleSeconds:       viper.GetInt(config.DisconnectAfterIdleTimeout),
 		InterruptionGracePeriod:          viper.GetInt(config.InterruptionGracePeriod),
 		EnvVars:                          hostEnvVars,
@@ -248,8 +248,8 @@ func validateConfiguration() {
 		}
 	}
 
-	if viper.GetString(config.RunJob) != "" && !viper.GetBool(config.DisconnectAfterJob) {
-		log.Fatalf("%s can only be used if %s is also used. Exiting...", config.RunJob, config.DisconnectAfterJob)
+	if viper.GetString(config.JobID) != "" && !viper.GetBool(config.DisconnectAfterJob) {
+		log.Fatalf("%s can only be used if %s is also used. Exiting...", config.JobID, config.DisconnectAfterJob)
 	}
 
 	uploadJobLogs := viper.GetString(config.UploadJobLogs)

--- a/main.go
+++ b/main.go
@@ -118,6 +118,7 @@ func RunListener(httpClient *http.Client, logfile io.Writer) {
 	_ = pflag.String(config.PreJobHookPath, "", "Pre-job hook path")
 	_ = pflag.String(config.PostJobHookPath, "", "Post-job hook path")
 	_ = pflag.Bool(config.DisconnectAfterJob, false, "Disconnect after job")
+	_ = pflag.String(config.RunJob, "", "Request a specific job to run")
 	_ = pflag.Int(config.DisconnectAfterIdleTimeout, 0, "Disconnect after idle timeout, in seconds")
 	_ = pflag.Int(config.InterruptionGracePeriod, 0, "The grace period, in seconds, to wait after receiving an interrupt signal")
 	_ = pflag.StringSlice(config.EnvVars, []string{}, "Export environment variables in jobs")
@@ -191,6 +192,7 @@ func RunListener(httpClient *http.Client, logfile io.Writer) {
 		PreJobHookPath:                   viper.GetString(config.PreJobHookPath),
 		PostJobHookPath:                  viper.GetString(config.PostJobHookPath),
 		DisconnectAfterJob:               viper.GetBool(config.DisconnectAfterJob),
+		RunJob:                           viper.GetString(config.RunJob),
 		DisconnectAfterIdleSeconds:       viper.GetInt(config.DisconnectAfterIdleTimeout),
 		InterruptionGracePeriod:          viper.GetInt(config.InterruptionGracePeriod),
 		EnvVars:                          hostEnvVars,
@@ -242,6 +244,10 @@ func validateConfiguration() {
 		if !slices.Contains(config.ValidConfigKeys, key) {
 			log.Fatalf("Unrecognized option '%s'. Exiting...", key)
 		}
+	}
+
+	if viper.GetString(config.RunJob) != "" && !viper.GetBool(config.DisconnectAfterJob) {
+		log.Fatalf("%s can only be used if %s is also used. Exiting...", config.RunJob, config.DisconnectAfterJob)
 	}
 
 	uploadJobLogs := viper.GetString(config.UploadJobLogs)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -13,6 +13,7 @@ const (
 	PreJobHookPath             = "pre-job-hook-path"
 	PostJobHookPath            = "post-job-hook-path"
 	DisconnectAfterJob         = "disconnect-after-job"
+	RunJob                     = "run-job"
 	DisconnectAfterIdleTimeout = "disconnect-after-idle-timeout"
 	EnvVars                    = "env-vars"
 	Files                      = "files"
@@ -68,6 +69,7 @@ var ValidConfigKeys = []string{
 	PreJobHookPath,
 	PostJobHookPath,
 	DisconnectAfterJob,
+	RunJob,
 	DisconnectAfterIdleTimeout,
 	EnvVars,
 	Files,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -13,7 +13,7 @@ const (
 	PreJobHookPath             = "pre-job-hook-path"
 	PostJobHookPath            = "post-job-hook-path"
 	DisconnectAfterJob         = "disconnect-after-job"
-	RunJob                     = "run-job"
+	JobID                      = "job-id"
 	DisconnectAfterIdleTimeout = "disconnect-after-idle-timeout"
 	EnvVars                    = "env-vars"
 	Files                      = "files"
@@ -69,7 +69,7 @@ var ValidConfigKeys = []string{
 	PreJobHookPath,
 	PostJobHookPath,
 	DisconnectAfterJob,
-	RunJob,
+	JobID,
 	DisconnectAfterIdleTimeout,
 	EnvVars,
 	Files,

--- a/pkg/listener/listener.go
+++ b/pkg/listener/listener.go
@@ -33,7 +33,7 @@ type Config struct {
 	PreJobHookPath                   string
 	PostJobHookPath                  string
 	DisconnectAfterJob               bool
-	RunJob                           string
+	JobID                            string
 	DisconnectAfterIdleSeconds       int
 	InterruptionGracePeriod          int
 	EnvVars                          []config.HostEnvVar
@@ -139,7 +139,7 @@ func (l *Listener) Register(name string) error {
 		SingleJob:               l.Config.DisconnectAfterJob,
 		IdleTimeout:             l.Config.DisconnectAfterIdleSeconds,
 		InterruptionGracePeriod: l.Config.InterruptionGracePeriod,
-		Job:                     l.Config.RunJob,
+		JobID:                   l.Config.JobID,
 	}
 
 	err := retry.RetryWithConstantWait(retry.RetryOptions{

--- a/pkg/listener/listener.go
+++ b/pkg/listener/listener.go
@@ -33,6 +33,7 @@ type Config struct {
 	PreJobHookPath                   string
 	PostJobHookPath                  string
 	DisconnectAfterJob               bool
+	RunJob                           string
 	DisconnectAfterIdleSeconds       int
 	InterruptionGracePeriod          int
 	EnvVars                          []config.HostEnvVar
@@ -138,6 +139,7 @@ func (l *Listener) Register(name string) error {
 		SingleJob:               l.Config.DisconnectAfterJob,
 		IdleTimeout:             l.Config.DisconnectAfterIdleSeconds,
 		InterruptionGracePeriod: l.Config.InterruptionGracePeriod,
+		Job:                     l.Config.RunJob,
 	}
 
 	err := retry.RetryWithConstantWait(retry.RetryOptions{

--- a/pkg/listener/selfhostedapi/register.go
+++ b/pkg/listener/selfhostedapi/register.go
@@ -21,7 +21,7 @@ type RegisterRequest struct {
 	SingleJob               bool   `json:"single_job"`
 	IdleTimeout             int    `json:"idle_timeout"`
 	InterruptionGracePeriod int    `json:"interruption_grace_period"`
-	Job                     string `json:"job"`
+	JobID                   string `json:"job_id"`
 }
 
 type RegisterResponse struct {

--- a/pkg/listener/selfhostedapi/register.go
+++ b/pkg/listener/selfhostedapi/register.go
@@ -21,6 +21,7 @@ type RegisterRequest struct {
 	SingleJob               bool   `json:"single_job"`
 	IdleTimeout             int    `json:"idle_timeout"`
 	InterruptionGracePeriod int    `json:"interruption_grace_period"`
+	Job                     string `json:"job"`
 }
 
 type RegisterResponse struct {


### PR DESCRIPTION
### Motivation

Currently, when an agent registers to run a single job, the Semaphore control plane assigns it a random job in the queue. However, some use cases require that the agent being registered runs a single specific job, not a random one, which is not possible right now.

### Solution

The registration request is changed to include a new `job_id` field. That field is used by the agent to indicate to the Semaphore control plane the specific job ID it wants to execute.