### PR TITLE
feat: add labels to kubernetes resources

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -83,6 +83,7 @@ var ValidConfigKeys = []string{
 	KubernetesPodSpec,
 	KubernetesAllowedImages,
 	KubernetesPodStartTimeout,
+	KubernetesLabels,
 }
 
 type HostEnvVar struct {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -26,6 +26,7 @@ const (
 	KubernetesPodSpec          = "kubernetes-pod-spec"
 	KubernetesAllowedImages    = "kubernetes-allowed-images"
 	KubernetesPodStartTimeout  = "kubernetes-pod-start-timeout"
+	KubernetesLabels           = "kubernetes-labels"
 )
 
 const DefaultKubernetesPodStartTimeout = 300

--- a/pkg/jobs/job.go
+++ b/pkg/jobs/job.go
@@ -49,6 +49,7 @@ type JobOptions struct {
 	UseKubernetesExecutor            bool
 	PodSpecDecoratorConfigMap        string
 	KubernetesPodStartTimeoutSeconds int
+	KubernetesLabels                 map[string]string
 	KubernetesImageValidator         *kubernetes.ImageValidator
 	UploadJobLogs                    string
 	RefreshTokenFn                   func() (string, error)
@@ -121,6 +122,7 @@ func CreateExecutor(request *api.JobRequest, logger *eventlogger.Logger, jobOpti
 			ImageValidator:            jobOptions.KubernetesImageValidator,
 			PodSpecDecoratorConfigMap: jobOptions.PodSpecDecoratorConfigMap,
 			PodPollingAttempts:        jobOptions.KubernetesPodStartTimeoutSeconds,
+			Labels:                    jobOptions.KubernetesLabels,
 			PodPollingInterval:        time.Second,
 		})
 	}

--- a/pkg/listener/job_processor.go
+++ b/pkg/listener/job_processor.go
@@ -46,6 +46,7 @@ func StartJobProcessor(httpClient *http.Client, apiClient *selfhostedapi.API, co
 		KubernetesPodSpec:                config.KubernetesPodSpec,
 		KubernetesImageValidator:         config.KubernetesImageValidator,
 		KubernetesPodStartTimeoutSeconds: config.KubernetesPodStartTimeoutSeconds,
+		KubernetesLabels:                 config.KubernetesLabels,
 	}
 
 	go p.Start()
@@ -90,6 +91,7 @@ type JobProcessor struct {
 	KubernetesPodSpec                string
 	KubernetesImageValidator         *kubernetes.ImageValidator
 	KubernetesPodStartTimeoutSeconds int
+	KubernetesLabels                 map[string]string
 }
 
 func (p *JobProcessor) Start() {
@@ -206,6 +208,7 @@ func (p *JobProcessor) RunJob(jobID string) {
 		UseKubernetesExecutor:            p.KubernetesExecutor,
 		PodSpecDecoratorConfigMap:        p.KubernetesPodSpec,
 		KubernetesPodStartTimeoutSeconds: p.KubernetesPodStartTimeoutSeconds,
+		KubernetesLabels:                 p.KubernetesLabels,
 		KubernetesImageValidator:         p.KubernetesImageValidator,
 		UploadJobLogs:                    p.UploadJobLogs,
 		RefreshTokenFn: func() (string, error) {

--- a/pkg/listener/listener.go
+++ b/pkg/listener/listener.go
@@ -49,6 +49,7 @@ type Config struct {
 	KubernetesPodSpec                string
 	KubernetesImageValidator         *kubernetes.ImageValidator
 	KubernetesPodStartTimeoutSeconds int
+	KubernetesLabels                 map[string]string
 }
 
 func Start(httpClient *http.Client, config Config) (*Listener, error) {


### PR DESCRIPTION
New `--kubernetes-labels` configuration parameter to specify labels that are added to all the Kubernetes resources created by Kubernetes executor.

### Usage

That parameter accepts a comma-separated list of key-value strings, similar to `--env-vars`. For example, if I want to list all pods created for a particular agent type, I can put the agent type name on a label:

```
./agent start \
  --endpoint semaphore.semaphoreci.com \
  --token "VERY_IMPORTANT_TOKEN" \
  --kubernetes-executor \
  --kubernetes-labels app=semaphore,semaphoreci.com/agent-type=s1-testing
```

And then use it when listing pods:

```
kubectl get pods -l semaphoreci.com/agent-type=s1-testing
```