### PR TITLE
feat: accept configuration from environment variables

### DIFF
--- a/main.go
+++ b/main.go
@@ -146,7 +146,7 @@ func RunListener(httpClient *http.Client, logfile io.Writer) {
 	viper.AutomaticEnv()
 	viper.SetEnvPrefix("SEMAPHORE_AGENT")
 
-	// Configuration parameters with a dash (-) on it can also be configured
+	// Configuration parameters with a dash (-) in their name can also be configured
 	// For example, --disconnect-after-job can be configured through SEMAPHORE_AGENT_DISCONNECT_AFTER_JOB.
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 

--- a/main.go
+++ b/main.go
@@ -112,7 +112,7 @@ func getLogFilePath() string {
 func RunListener(httpClient *http.Client, logfile io.Writer) {
 	configFile := pflag.String(config.ConfigFile, "", "Config file")
 	_ = pflag.String(config.Name, "", "Name to use for the agent. If not set, a default random one is used.")
-	_ = pflag.String(config.NameFromEnv, "", "Specify name to use for the agent, using an environment variable. If --name and --name-from-env are empty, a random one is generated.")
+	_ = pflag.String(config.NameFromEnv, "", "Specify name to use for the agent, using an environment variable. Deprecated, use SEMAPHORE_AGENT_NAME instead.")
 	_ = pflag.String(config.Endpoint, "", "Endpoint where agents are registered")
 	_ = pflag.String(config.Token, "", "Registration token")
 	_ = pflag.Bool(config.NoHTTPS, false, "Use http for communication")
@@ -139,6 +139,16 @@ func RunListener(httpClient *http.Client, logfile io.Writer) {
 	)
 
 	pflag.Parse()
+
+	// Specifying configuration parameters with
+	// environment variables should also be possible through a SEMAPHORE_AGENT_ prefix,
+	// e.g., --endpoint can be specified with SEMAPHORE_AGENT_ENDPOINT.
+	viper.AutomaticEnv()
+	viper.SetEnvPrefix("SEMAPHORE_AGENT")
+
+	// Configuration parameters with a dash (-) on it can also be configured
+	// For example, --disconnect-after-job can be configured through SEMAPHORE_AGENT_DISCONNECT_AFTER_JOB.
+	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 
 	if *configFile != "" {
 		loadConfigFile(*configFile)


### PR DESCRIPTION
### Issue

Currently, there's no way to specify the agent configuration using environment variables. One use case where being able to do so would be helpful is when starting agents in a Kubernetes pod without a configuration file. Currently, you need to specify the `--token <VERY_SENSITIVE_TOKEN>` in the container's startup command, but that is not safe since it exposes the registration token.

### Solution

We allow configuration parameters to be specified by using a `SEMAPHORE_AGENT` prefix. For example, currently you have to specify parameters as:

```
./agent start \
  --endpoint test.semaphoreci.com \
  --token token123 \
  --disconnect-after-job
```

With this change, you will be able to do it with:

```
export SEMAPHORE_AGENT_ENDPOINT=test.semaphoreci.com
export SEMAPHORE_AGENT_TOKEN=token123
export SEMAPHORE_AGENT_DISCONNECT_AFTER_JOB=true
./agent start
```

You can also mix the two:

```
export SEMAPHORE_AGENT_ENV_VARS="VAR_1=1 VAR_2=2" ./agent start \
  --endpoint test.semaphoreci.com \
  --token token123 \
  --disconnect-after-job
```

### Deprecation

We currently have a `--name-from-env` configuration parameter with the intention of grabbing configuration from the environment, but that doesn't scale well. I updated the description on that one, to mention that using `SEMAPHORE_AGENT_NAME` is the recommended way, and deprecating that flag.