### PR TITLE
fix: no sleep when flushing output buffer

### DIFF
--- a/pkg/retry/retry.go
+++ b/pkg/retry/retry.go
@@ -49,6 +49,8 @@ func RetryWithConstantWaitAndContext(ctx context.Context, options RetryOptions) 
 			)
 		}
 
-		time.Sleep(options.DelayBetweenAttempts)
+		if options.DelayBetweenAttempts > 0 {
+			time.Sleep(options.DelayBetweenAttempts)
+		}
 	}
 }

--- a/pkg/shell/output_buffer_test.go
+++ b/pkg/shell/output_buffer_test.go
@@ -188,6 +188,11 @@ func Test__OutputBuffer__DoesNotWaitForeverForOutputToBeFlushed(t *testing.T) {
 
 	buffer, _ := NewOutputBufferWithFlushTimeout(func(s string) {}, time.Second)
 
+	// write a lot of data to the buffer
+	for i := 0; i < 100; i++ {
+		buffer.Append(input)
+	}
+
 	// on a separate goroutine, we continuosly write
 	// to make sure the buffer is never empty
 	go func() {

--- a/pkg/shell/output_buffer_test.go
+++ b/pkg/shell/output_buffer_test.go
@@ -189,7 +189,7 @@ func Test__OutputBuffer__DoesNotWaitForeverForOutputToBeFlushed(t *testing.T) {
 	buffer, _ := NewOutputBufferWithFlushTimeout(func(s string) {}, time.Second)
 
 	// write a lot of data to the buffer
-	for i := 0; i < 100; i++ {
+	for i := 0; i < 10000; i++ {
 		buffer.Append(input)
 	}
 

--- a/pkg/shell/shell_test.go
+++ b/pkg/shell/shell_test.go
@@ -25,6 +25,8 @@ func Test__Shell__NewShell(t *testing.T) {
 	} else {
 		assert.Equal(t, shell.Args, []string{"--login"})
 	}
+
+	assert.NoError(t, shell.Close())
 }
 
 func Test__Shell__Start(t *testing.T) {
@@ -41,6 +43,8 @@ func Test__Shell__Start(t *testing.T) {
 		assert.NotNil(t, shell.BootCommand)
 		assert.NotNil(t, shell.TTY)
 	}
+
+	assert.NoError(t, shell.Close())
 }
 
 func Test__Shell__SimpleHelloWorld(t *testing.T) {
@@ -55,6 +59,7 @@ func Test__Shell__SimpleHelloWorld(t *testing.T) {
 
 	p1.Run()
 	assert.Equal(t, output.String(), "Hello\n")
+	assert.NoError(t, shell.Close())
 }
 
 func Test__Shell__SimpleHelloWorldUsingBase64Encoding(t *testing.T) {
@@ -78,6 +83,7 @@ func Test__Shell__SimpleHelloWorldUsingBase64Encoding(t *testing.T) {
 
 	p1.Run()
 	assert.Equal(t, output.String(), "Hello\n")
+	assert.NoError(t, shell.Close())
 }
 
 func Test__Shell__HandlingBashProcessKill(t *testing.T) {


### PR DESCRIPTION
Related to https://github.com/renderedtext/tasks/issues/5043.

### Issue

Currently, if a command generates more than 1MB of output right when it ends, the agent is not able to consume all that output in time.

### Solution

We are currently sleeping 10ms between each output buffer flushing operation. We shouldn't do that since it limits how much output we can consume. We should just let the output buffer flush itself as fast as it can, for as long as we want it.

We achieve that by controlling how much time is spent on flushing with a context that expires after 1 minute instead of using a maximum number of attempts and a sleeping period between each attempt.