### PR TITLE
fix: configure hostAliases for sidecar containers

### DIFF
--- a/docs/kubernetes-executor.md
+++ b/docs/kubernetes-executor.md
@@ -44,7 +44,6 @@ The Kubernetes permissions required by the agent to use the Kubernetes executor 
 
 ## Limitations
 
-- Sidecar containers are addressable through localhost, and not through DNS names.
 - Running system-level software such as systemd and Docker requires privileged access to the Kubernetes nodes, which is not safe. If you need to run those workflows, consider using the [agent-aws-stack](https://github.com/renderedtext/agent-aws-stack) or [sysbox](https://github.com/nestybox/sysbox).
 
 ## Configuration

--- a/pkg/kubernetes/client_test.go
+++ b/pkg/kubernetes/client_test.go
@@ -308,6 +308,7 @@ func Test__CreatePod(t *testing.T) {
 			Get(context.Background(), podName, v1.GetOptions{})
 
 		assert.NoError(t, err)
+		assert.Empty(t, pod.Spec.HostAliases)
 
 		// assert pod spec containers
 		if assert.Len(t, pod.Spec.Containers, 1) {
@@ -448,6 +449,7 @@ func Test__CreatePod(t *testing.T) {
 			Get(context.Background(), podName, v1.GetOptions{})
 
 		assert.NoError(t, err)
+		assert.Equal(t, pod.Spec.HostAliases, []corev1.HostAlias{{IP: "127.0.0.1", Hostnames: []string{"db"}}})
 
 		// assert 2 containers are used and command and volume mounts are only set for the main one
 		if assert.Len(t, pod.Spec.Containers, 2) {


### PR DESCRIPTION
### Issue

Currently, when using the Kubernetes executor, if additional containers (db, redis, ...) are used in a job, they are only available through localhost, and not through their DNS names, like with the docker compose executor.

### Solution

We populate the [hostAliases](https://kubernetes.io/docs/tasks/network/customize-hosts-file-for-pods/) field for the pod created for the job with the container names coming from the Semaphore YAML.