### PR TITLE
fix: upload job logs as artifact from agent location

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -125,6 +125,7 @@ blocks:
                 - command_aliases
                 - env_vars
                 - failed_job
+                - job_logs_as_artifact
                 - job_stopping
                 - job_stopping_on_epilogue
                 - file_injection
@@ -270,6 +271,7 @@ blocks:
                 - docker_compose__epilogue
                 - docker_compose__file-injection
                 - docker_compose__multiple-containers
+                - job_logs_as_artifact
                 - private_image_gcr
                 - private_image_ecr_no_account_id
                 - private_image_ecr_with_account_id

--- a/pkg/jobs/job.go
+++ b/pkg/jobs/job.go
@@ -529,6 +529,8 @@ func (job *Job) uploadLogsAsArtifact(trimmed bool) {
 	}
 
 	args := []string{"push", "job", file, "-d", "agent/job_logs.txt"}
+
+	// #nosec
 	cmd := exec.Command(path, args...)
 	cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", "SEMAPHORE_ARTIFACT_TOKEN", token))
 	output, err := cmd.CombinedOutput()

--- a/test/e2e/docker/job_logs_as_artifact.rb
+++ b/test/e2e/docker/job_logs_as_artifact.rb
@@ -1,6 +1,19 @@
 #!/bin/ruby
 # rubocop:disable all
 
+$AGENT_CONFIG = {
+  "endpoint" => "localhost:4567",
+  "token" => "321h1l2jkh1jk42341",
+  "no-https" => true,
+  "shutdown-hook-path" => "",
+  "disconnect-after-job" => false,
+  "env-vars" => [],
+  "files" => [],
+  "fail-on-missing-files" => false,
+  "upload-job-logs" => "always"
+}
+
+
 require_relative '../../e2e'
 
 # Here, we use the SEMAPHORE_JOB_ID as the job ID for this test.

--- a/test/e2e/docker/job_logs_as_artifact.rb
+++ b/test/e2e/docker/job_logs_as_artifact.rb
@@ -1,0 +1,85 @@
+#!/bin/ruby
+# rubocop:disable all
+
+require_relative '../../e2e'
+
+# Here, we use the SEMAPHORE_JOB_ID as the job ID for this test.
+$JOB_ID = ENV["SEMAPHORE_JOB_ID"]
+
+# Additionally, we pass the artifact related environment variables
+# to the job, so that it can upload the job logs as an artifact after the job is done.
+start_job <<-JSON
+  {
+    "job_id": "#{$JOB_ID}",
+    "executor": "dockercompose",
+    "compose": {
+      "containers": [
+        {
+          "name": "main",
+          "image": "ruby:2.6"
+        }
+      ]
+    },
+    "env_vars": [
+      { "name": "SEMAPHORE_JOB_ID", "value": "#{Base64.strict_encode64(ENV["SEMAPHORE_JOB_ID"])}" },
+      { "name": "SEMAPHORE_ORGANIZATION_URL", "value": "#{Base64.strict_encode64(ENV["SEMAPHORE_ORGANIZATION_URL"])}" },
+      { "name": "SEMAPHORE_ARTIFACT_TOKEN", "value": "#{Base64.strict_encode64(ENV["SEMAPHORE_ARTIFACT_TOKEN"])}" },
+      { "name": "SEMAPHORE_AGENT_UPLOAD_JOB_LOGS", "value": "#{Base64.strict_encode64("always")}" }
+    ],
+    "files": [],
+    "commands": [
+      { "directive": "for i in {1..10}; do echo \\\"[$i] this is some output, just for testing purposes\\\" && sleep 1; done" }
+    ],
+    "epilogue_always_commands": [],
+    "callbacks": {
+      "finished": "#{finished_callback_url}",
+      "teardown_finished": "#{teardown_callback_url}"
+    },
+    "logger": #{$LOGGER}
+  }
+JSON
+
+wait_for_job_to_finish
+
+assert_job_log <<-LOG
+  {"event":"job_started",  "timestamp":"*"}
+
+  {"event":"cmd_started",  "timestamp":"*", "directive":"Pulling docker images..."}
+  *** LONG_OUTPUT ***
+  {"event":"cmd_finished", "timestamp":"*", "directive":"Pulling docker images...","event":"cmd_finished","exit_code":0,"finished_at":"*","started_at":"*","timestamp":"*"}
+
+  {"event":"cmd_started",  "timestamp":"*", "directive":"Starting the docker image..."}
+  {"event":"cmd_output",   "timestamp":"*", "output":"Starting a new bash session.\\n"}
+  {"event":"cmd_finished", "timestamp":"*", "directive":"Starting the docker image...","event":"cmd_finished","exit_code":0,"finished_at":"*","started_at":"*","timestamp":"*"}
+
+  {"event":"cmd_started",  "timestamp":"*", "directive":"Exporting environment variables"}
+  {"event":"cmd_output",   "timestamp":"*", "output":"Exporting SEMAPHORE_AGENT_UPLOAD_JOB_LOGS\\n"}
+  {"event":"cmd_output",   "timestamp":"*", "output":"Exporting SEMAPHORE_ARTIFACT_TOKEN\\n"}
+  {"event":"cmd_output",   "timestamp":"*", "output":"Exporting SEMAPHORE_JOB_ID\\n"}
+  {"event":"cmd_output",   "timestamp":"*", "output":"Exporting SEMAPHORE_ORGANIZATION_URL\\n"}
+  {"event":"cmd_finished", "timestamp":"*", "directive":"Exporting environment variables","exit_code":0,"finished_at":"*","started_at":"*"}
+
+  {"event":"cmd_started",  "timestamp":"*", "directive":"Injecting Files"}
+  {"event":"cmd_finished", "timestamp":"*", "directive":"Injecting Files","exit_code":0,"finished_at":"*","started_at":"*"}
+
+  {"event":"cmd_started",  "timestamp":"*", "directive":"for i in {1..10}; do echo \\"[$i] this is some output, just for testing purposes\\" && sleep 1; done"}
+  {"event":"cmd_output",   "timestamp":"*", "output":"[1] this is some output, just for testing purposes\\n"}
+  {"event":"cmd_output",   "timestamp":"*", "output":"[2] this is some output, just for testing purposes\\n"}
+  {"event":"cmd_output",   "timestamp":"*", "output":"[3] this is some output, just for testing purposes\\n"}
+  {"event":"cmd_output",   "timestamp":"*", "output":"[4] this is some output, just for testing purposes\\n"}
+  {"event":"cmd_output",   "timestamp":"*", "output":"[5] this is some output, just for testing purposes\\n"}
+  {"event":"cmd_output",   "timestamp":"*", "output":"[6] this is some output, just for testing purposes\\n"}
+  {"event":"cmd_output",   "timestamp":"*", "output":"[7] this is some output, just for testing purposes\\n"}
+  {"event":"cmd_output",   "timestamp":"*", "output":"[8] this is some output, just for testing purposes\\n"}
+  {"event":"cmd_output",   "timestamp":"*", "output":"[9] this is some output, just for testing purposes\\n"}
+  {"event":"cmd_output",   "timestamp":"*", "output":"[10] this is some output, just for testing purposes\\n"}
+  {"event":"cmd_finished", "timestamp":"*", "directive":"for i in {1..10}; do echo \\"[$i] this is some output, just for testing purposes\\" && sleep 1; done","exit_code":0,"finished_at":"*","started_at":"*"}
+
+  {"event":"cmd_started",  "timestamp":"*", "directive":"Exporting environment variables"}
+  {"event":"cmd_output",   "timestamp":"*", "output":"Exporting SEMAPHORE_JOB_RESULT\\n"}
+  {"event":"cmd_finished", "timestamp":"*", "directive":"Exporting environment variables","exit_code":0,"started_at":"*","finished_at":"*"}
+
+  {"event":"job_finished", "timestamp":"*", "result":"passed"}
+LOG
+
+assert_artifact_is_available

--- a/test/e2e/kubernetes/job_logs_as_artifact.rb
+++ b/test/e2e/kubernetes/job_logs_as_artifact.rb
@@ -38,10 +38,10 @@ start_job <<-JSON
     },
 
     "env_vars": [
-      { "name": "SEMAPHORE_JOB_ID", "value": "#{Base64.strict_encode64(ENV["SEMAPHORE_JOB_ID"])}" },
-      { "name": "SEMAPHORE_ORGANIZATION_URL", "value": "#{Base64.strict_encode64(ENV["SEMAPHORE_ORGANIZATION_URL"])}" },
+      { "name": "SEMAPHORE_AGENT_UPLOAD_JOB_LOGS", "value": "#{Base64.strict_encode64("always")}" },
       { "name": "SEMAPHORE_ARTIFACT_TOKEN", "value": "#{Base64.strict_encode64(ENV["SEMAPHORE_ARTIFACT_TOKEN"])}" },
-      { "name": "SEMAPHORE_AGENT_UPLOAD_JOB_LOGS", "value": "#{Base64.strict_encode64("always")}" }
+      { "name": "SEMAPHORE_JOB_ID", "value": "#{Base64.strict_encode64(ENV["SEMAPHORE_JOB_ID"])}" },
+      { "name": "SEMAPHORE_ORGANIZATION_URL", "value": "#{Base64.strict_encode64(ENV["SEMAPHORE_ORGANIZATION_URL"])}" }
     ],
     "files": [],
     "commands": [

--- a/test/e2e/kubernetes/job_logs_as_artifact.rb
+++ b/test/e2e/kubernetes/job_logs_as_artifact.rb
@@ -1,0 +1,103 @@
+#!/bin/ruby
+# rubocop:disable all
+
+$AGENT_CONFIG = {
+  "endpoint" => "localhost:4567",
+  "token" => "321h1l2jkh1jk42341",
+  "no-https" => true,
+  "shutdown-hook-path" => "",
+  "disconnect-after-job" => false,
+  "env-vars" => [],
+  "files" => [],
+  "fail-on-missing-files" => false,
+  "kubernetes-executor" => true,
+  "upload-job-logs" => "always"
+}
+
+# Here, we use the SEMAPHORE_JOB_ID as the job ID for this test.
+$JOB_ID = ENV["SEMAPHORE_JOB_ID"]
+
+require_relative '../../e2e'
+
+start_job <<-JSON
+  {
+    "job_id": "#{$JOB_ID}",
+
+    "executor": "dockercompose",
+
+    "compose": {
+      "containers": [
+        {
+          "name": "main",
+          "image": "ruby:3-slim",
+          "env_vars": [
+            { "name": "FOO", "value": "#{`echo "bar" | base64 | tr -d '\n'`}" }
+          ]
+        }
+      ]
+    },
+
+    "env_vars": [
+      { "name": "SEMAPHORE_JOB_ID", "value": "#{Base64.strict_encode64(ENV["SEMAPHORE_JOB_ID"])}" },
+      { "name": "SEMAPHORE_ORGANIZATION_URL", "value": "#{Base64.strict_encode64(ENV["SEMAPHORE_ORGANIZATION_URL"])}" },
+      { "name": "SEMAPHORE_ARTIFACT_TOKEN", "value": "#{Base64.strict_encode64(ENV["SEMAPHORE_ARTIFACT_TOKEN"])}" },
+      { "name": "SEMAPHORE_AGENT_UPLOAD_JOB_LOGS", "value": "#{Base64.strict_encode64("always")}" }
+    ],
+    "files": [],
+    "commands": [
+      { "directive": "for i in {1..10}; do echo \\\"[$i] this is some output, just for testing purposes\\\" && sleep 1; done" }
+    ],
+
+    "files": [],
+    "epilogue_always_commands": [],
+    "callbacks": {
+      "finished": "#{finished_callback_url}",
+      "teardown_finished": "#{teardown_callback_url}"
+    },
+    "logger": #{$LOGGER}
+  }
+JSON
+
+wait_for_job_to_finish
+
+assert_job_log <<-LOG
+  {"event":"job_started",  "timestamp":"*"}
+
+  {"event":"cmd_started",  "timestamp":"*", "directive":"Creating Kubernetes resources for job..."}
+  {"event":"cmd_finished", "timestamp":"*", "directive":"Creating Kubernetes resources for job...","event":"cmd_finished","exit_code":0,"finished_at":"*","started_at":"*","timestamp":"*"}
+
+  {"event":"cmd_started",  "timestamp":"*", "directive":"Starting shell session..."}
+  *** LONG_OUTPUT ***
+  {"event":"cmd_finished", "timestamp":"*", "directive":"Starting shell session...","event":"cmd_finished","exit_code":0,"finished_at":"*","started_at":"*","timestamp":"*"}
+
+  {"event":"cmd_started",  "timestamp":"*", "directive":"Exporting environment variables"}
+  {"event":"cmd_output",   "timestamp":"*", "output":"Exporting SEMAPHORE_AGENT_UPLOAD_JOB_LOGS\\n"}
+  {"event":"cmd_output",   "timestamp":"*", "output":"Exporting SEMAPHORE_ARTIFACT_TOKEN\\n"}
+  {"event":"cmd_output",   "timestamp":"*", "output":"Exporting SEMAPHORE_JOB_ID\\n"}
+  {"event":"cmd_output",   "timestamp":"*", "output":"Exporting SEMAPHORE_ORGANIZATION_URL\\n"}
+  {"event":"cmd_finished", "timestamp":"*", "directive":"Exporting environment variables","exit_code":0,"finished_at":"*","started_at":"*"}
+
+  {"event":"cmd_started",  "timestamp":"*", "directive":"Injecting Files"}
+  {"event":"cmd_finished", "timestamp":"*", "directive":"Injecting Files","exit_code":0,"finished_at":"*","started_at":"*"}
+
+  {"event":"cmd_started",  "timestamp":"*", "directive":"for i in {1..10}; do echo \\"[$i] this is some output, just for testing purposes\\" && sleep 1; done"}
+  {"event":"cmd_output",   "timestamp":"*", "output":"[1] this is some output, just for testing purposes\\n"}
+  {"event":"cmd_output",   "timestamp":"*", "output":"[2] this is some output, just for testing purposes\\n"}
+  {"event":"cmd_output",   "timestamp":"*", "output":"[3] this is some output, just for testing purposes\\n"}
+  {"event":"cmd_output",   "timestamp":"*", "output":"[4] this is some output, just for testing purposes\\n"}
+  {"event":"cmd_output",   "timestamp":"*", "output":"[5] this is some output, just for testing purposes\\n"}
+  {"event":"cmd_output",   "timestamp":"*", "output":"[6] this is some output, just for testing purposes\\n"}
+  {"event":"cmd_output",   "timestamp":"*", "output":"[7] this is some output, just for testing purposes\\n"}
+  {"event":"cmd_output",   "timestamp":"*", "output":"[8] this is some output, just for testing purposes\\n"}
+  {"event":"cmd_output",   "timestamp":"*", "output":"[9] this is some output, just for testing purposes\\n"}
+  {"event":"cmd_output",   "timestamp":"*", "output":"[10] this is some output, just for testing purposes\\n"}
+  {"event":"cmd_finished", "timestamp":"*", "directive":"for i in {1..10}; do echo \\"[$i] this is some output, just for testing purposes\\" && sleep 1; done","exit_code":0,"finished_at":"*","started_at":"*"}
+
+  {"event":"cmd_started",  "timestamp":"*", "directive":"Exporting environment variables"}
+  {"event":"cmd_output",   "timestamp":"*", "output":"Exporting SEMAPHORE_JOB_RESULT\\n"}
+  {"event":"cmd_finished", "timestamp":"*", "directive":"Exporting environment variables","exit_code":0,"started_at":"*","finished_at":"*"}
+
+  {"event":"job_finished", "timestamp":"*", "result":"passed"}
+LOG
+
+assert_artifact_is_available

--- a/test/e2e/kubernetes/job_logs_as_artifact.rb
+++ b/test/e2e/kubernetes/job_logs_as_artifact.rb
@@ -14,10 +14,10 @@ $AGENT_CONFIG = {
   "upload-job-logs" => "always"
 }
 
+require_relative '../../e2e'
+
 # Here, we use the SEMAPHORE_JOB_ID as the job ID for this test.
 $JOB_ID = ENV["SEMAPHORE_JOB_ID"]
-
-require_relative '../../e2e'
 
 start_job <<-JSON
   {


### PR DESCRIPTION
### Issue

We are currently executing the artifact CLI command to upload the job logs inside of the PTY. There are two problems with that approach:
1. It doesn’t work for jobs that are stopped, since the PTY is closed when the job is stopped.
2. It doesn’t work for the docker-compose and kubernetes executors, since the logs are where the agent is, not where the job is running.

### Solution

Use [os/exec](https://pkg.go.dev/os/exec) to execute the artifact CLI command from the agent, passing all the necessary environment variables to the artifact CLI command from the environment variables present in the job request.