### PR TITLE
fix(kubernetes): do not use home directory from agent when injecting files

### DIFF
--- a/pkg/executors/kubernetes_executor.go
+++ b/pkg/executors/kubernetes_executor.go
@@ -205,6 +205,20 @@ func (e *KubernetesExecutor) Start() int {
 
 	log.Infof("User identity: %s", output)
 	e.logger.LogCommandOutput(fmt.Sprintf("User identity: %s", output))
+
+	// Find the working directory.
+	// Mostly helpful when troubleshooting issues with permissions on the container.
+	output, code = e.GetOutputFromCommand("pwd")
+	if code != 0 {
+		log.Errorf("Failed to determine working directory: exit code %d - %s", code, output)
+		e.logger.LogCommandOutput("Failed to determine working directory\n")
+		e.logger.LogCommandOutput(fmt.Sprintf("exit code %d - %s", code, output))
+		exitCode = code
+		return exitCode
+	}
+
+	log.Infof("Working directory: %s", output)
+	e.logger.LogCommandOutput(fmt.Sprintf("Working directory: %s", output))
 	return exitCode
 }
 


### PR DESCRIPTION
https://github.com/renderedtext/tasks/issues/5830

### Issue

When injecting files, the Kubernetes executor is not properly resolving their paths. It is currently using the home directory where the agent is running, not where the job is running. This makes it hard for troubleshooting issues with file injection.

### Solution

Use a similar resolving logic as the one used in the docker-compose executor: inject file into the home directory where the job is running unless the file path is already an absolute one or already contains `~`. Additionally, we also include a few additional commands right after the PTY session is started to gather a little bit more detail into the user running the commands, which should help us troubleshoot permission issues on the containers being used to run the jobs.