### PR TITLE
feat: exit job early successfully

### DIFF
--- a/pkg/executors/docker_compose_executor.go
+++ b/pkg/executors/docker_compose_executor.go
@@ -2,6 +2,7 @@ package executors
 
 import (
 	"bufio"
+	"bytes"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -710,6 +711,16 @@ func (e *DockerComposeExecutor) InjectFiles(files []api.File) int {
 	e.Logger.LogCommandFinished(directive, exitCode, commandStartedAt, commandFinishedAt)
 
 	return exitCode
+}
+
+func (e *DockerComposeExecutor) GetOutputFromCommand(command string) (string, int) {
+	out := bytes.Buffer{}
+	p := e.Shell.NewProcessWithOutput(command, func(output string) {
+		out.WriteString(output)
+	})
+
+	p.Run()
+	return out.String(), p.ExitCode
 }
 
 func (e *DockerComposeExecutor) RunCommand(command string, silent bool, alias string) int {

--- a/pkg/executors/executor.go
+++ b/pkg/executors/executor.go
@@ -12,6 +12,7 @@ type Executor interface {
 	InjectFiles([]api.File) int
 	RunCommand(string, bool, string) int
 	RunCommandWithOptions(options CommandOptions) int
+	GetOutputFromCommand(string) (string, int)
 	Stop() int
 	Cleanup() int
 }

--- a/pkg/executors/shell_executor.go
+++ b/pkg/executors/shell_executor.go
@@ -1,6 +1,7 @@
 package executors
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -224,6 +225,17 @@ func (e *ShellExecutor) InjectFiles(files []api.File) int {
 	e.Logger.LogCommandFinished(directive, exitCode, commandStartedAt, commandFinishedAt)
 
 	return exitCode
+}
+
+func (e *ShellExecutor) GetOutputFromCommand(command string) (string, int) {
+	out := bytes.Buffer{}
+	p := e.Shell.NewProcessWithOutput(command, func(output string) {
+		out.WriteString(output)
+	})
+
+	p.Run()
+
+	return out.String(), p.ExitCode
 }
 
 func (e *ShellExecutor) RunCommand(command string, silent bool, alias string) int {

--- a/pkg/jobs/job.go
+++ b/pkg/jobs/job.go
@@ -349,7 +349,9 @@ func (job *Job) handleStopExitCode() string {
 		job.Logger.LogCommandOutput("SEMAPHORE_JOB_RESULT=failed - stopping job and marking it as failed")
 		return JobFailed
 	default:
-		job.Logger.LogCommandOutput("SEMAPHORE_JOB_RESULT is set to '%s', stopping job")
+		job.Logger.LogCommandOutput(fmt.Sprintf(
+			"SEMAPHORE_JOB_RESULT is set to '%s', stopping job and marking it as stopped", status),
+		)
 		return JobStopped
 	}
 }

--- a/pkg/jobs/job.go
+++ b/pkg/jobs/job.go
@@ -350,7 +350,7 @@ func (job *Job) handleStopExitCode() string {
 		return JobFailed
 	default:
 		job.Logger.LogCommandOutput(fmt.Sprintf(
-			"SEMAPHORE_JOB_RESULT is set to '%s', stopping job and marking it as stopped", status),
+			"SEMAPHORE_JOB_RESULT is set to '%s' - stopping job and marking it as stopped", status),
 		)
 		return JobStopped
 	}


### PR DESCRIPTION
https://github.com/renderedtext/tasks/issues/5209

### Issue

Currently, you can already stop a job by returning exit code 130 from a command. However, the job will be marked as stopped in the UI. There might be cases where one might want to stop the job early, but mark it as passed or failed, and not stopped.

### Solution

When an exit code 130 is returned from a command, use the `SEMAPHORE_JOB_RESULT` environment to determine the job result for the job:
- If `SEMAPHORE_JOB_RESULT=passed`, the job is stopped and marked as successful
- If `SEMAPHORE_JOB_RESULT=failed`, the job is stopped and marked as failed
- If anything else, the job is stopped and marked as stopped