### PR TITLE
fix: goreleaser config for goreleaser v2

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,4 @@
+version: 2
 project_name: agent
 before:
   hooks:
@@ -75,7 +76,7 @@ brews:
     commit_author:
       name: release-bot-agent
       email: contact+release-bot-agent@renderedtext.com
-    folder: Formula
+    directory: Formula
     homepage:  https://semaphoreci.com
     description: Semaphore 2.0 agent.
     test: |


### PR DESCRIPTION
https://github.com/renderedtext/tasks/issues/6241

GoReleaser v2 was released a [few weeks ago](https://goreleaser.com/blog/goreleaser-v2/), which caused [this job](https://semaphore.semaphoreci.com/jobs/878c8dd6-84de-4212-8520-ee92059474fa) to fail. This pull request updates the GoReleaser configuration appropriately to use the v2.