### PR TITLE
fix: make callback retry attempts configurable

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -89,6 +89,7 @@ blocks:
     task:
       secrets:
         - name: aws-ecr-agent-e2e-secret
+        - name: hellopuller
         - name: gcr-test-secret
         - name: docker-registry-test-secret
       env_vars:

--- a/main.go
+++ b/main.go
@@ -370,6 +370,7 @@ func RunServer(httpClient *http.Client, logfile io.Writer) {
 	statsdHost := pflag.String("statsd-host", "", "Metrics Host")
 	statsdPort := pflag.String("statsd-port", "", "Metrics port")
 	statsdNamespace := pflag.String("statsd-namespace", "agent.prod", "The prefix to be added to every StatsD metric")
+	callbackRetryAttempts := pflag.Int("callback-retry-attempts", server.DefaultCallbackRetryAttempts, "Number of times to retry sending the callback after the job is finished")
 	preJobHookPath := pflag.String(config.PreJobHookPath, "", "The path to a pre-job hook script")
 	files := pflag.StringSlice(config.Files, []string{}, "Inject files into container, when using docker compose executor")
 
@@ -392,17 +393,20 @@ func RunServer(httpClient *http.Client, logfile io.Writer) {
 		log.Fatalf("Error parsing --files: %v", err)
 	}
 
+	log.Infof("Callback retry attempts: %d", *callbackRetryAttempts)
+
 	server.NewServer(server.ServerConfig{
-		Host:           *host,
-		Port:           *port,
-		TLSCertPath:    *tlsCertPath,
-		TLSKeyPath:     *tlsKeyPath,
-		Version:        VERSION,
-		LogFile:        logfile,
-		JWTSecret:      []byte(*authTokenSecret),
-		HTTPClient:     httpClient,
-		PreJobHookPath: *preJobHookPath,
-		FileInjections: fileInjections,
+		Host:                  *host,
+		Port:                  *port,
+		TLSCertPath:           *tlsCertPath,
+		TLSKeyPath:            *tlsKeyPath,
+		Version:               VERSION,
+		LogFile:               logfile,
+		JWTSecret:             []byte(*authTokenSecret),
+		HTTPClient:            httpClient,
+		PreJobHookPath:        *preJobHookPath,
+		FileInjections:        fileInjections,
+		CallbackRetryAttempts: *callbackRetryAttempts,
 	}).Serve()
 }
 

--- a/test/e2e/docker/docker_private_image_ecr.rb
+++ b/test/e2e/docker/docker_private_image_ecr.rb
@@ -58,7 +58,7 @@ assert_job_log <<-LOG
   {"event":"cmd_output",   "timestamp":"*", "output":"WARNING! Using --password via the CLI is insecure. Use --password-stdin.\\n"}
   {"event":"cmd_output",   "timestamp":"*", "output":"WARNING! Your password will be stored unencrypted in /root/.docker/config.json.\\n"}
   {"event":"cmd_output",   "timestamp":"*", "output":"Configure a credential helper to remove this warning. See\\n"}
-  {"event":"cmd_output",   "timestamp":"*", "output":"https://docs.docker.com/engine/reference/commandline/login/#credentials-store\\n"}
+  {"event":"cmd_output",   "timestamp":"*", "output":"https://docs.docker.com/engine/reference/commandline/login/#credential-stores\\n"}
   {"event":"cmd_output",   "timestamp":"*", "output":"\\n"}
   {"event":"cmd_output",   "timestamp":"*", "output":"Login Succeeded\\n"}
   {"event":"cmd_output",   "timestamp":"*", "output":"\\n"}

--- a/test/e2e/docker/docker_private_image_ecr_account_id.rb
+++ b/test/e2e/docker/docker_private_image_ecr_account_id.rb
@@ -61,7 +61,7 @@ assert_job_log <<-LOG
   {"event":"cmd_output",   "timestamp":"*", "output":"WARNING! Using --password via the CLI is insecure. Use --password-stdin.\\n"}
   {"event":"cmd_output",   "timestamp":"*", "output":"WARNING! Your password will be stored unencrypted in /root/.docker/config.json.\\n"}
   {"event":"cmd_output",   "timestamp":"*", "output":"Configure a credential helper to remove this warning. See\\n"}
-  {"event":"cmd_output",   "timestamp":"*", "output":"https://docs.docker.com/engine/reference/commandline/login/#credentials-store\\n"}
+  {"event":"cmd_output",   "timestamp":"*", "output":"https://docs.docker.com/engine/reference/commandline/login/#credential-stores\\n"}
   {"event":"cmd_output",   "timestamp":"*", "output":"\\n"}
   {"event":"cmd_output",   "timestamp":"*", "output":"Login Succeeded\\n"}
   {"event":"cmd_output",   "timestamp":"*", "output":"\\n"}

--- a/test/e2e/docker/docker_private_image_ecr_account_id_v2.rb
+++ b/test/e2e/docker/docker_private_image_ecr_account_id_v2.rb
@@ -65,7 +65,7 @@ assert_job_log <<-LOG
   {"event":"cmd_output",   "timestamp":"*", "output":"aws ecr get-login-password --region $AWS_REGION | docker login --username AWS --password-stdin #{aws_account_id}.dkr.ecr.$AWS_REGION.amazonaws.com\\n"}
   {"event":"cmd_output",   "timestamp":"*", "output":"WARNING! Your password will be stored unencrypted in /root/.docker/config.json.\\n"}
   {"event":"cmd_output",   "timestamp":"*", "output":"Configure a credential helper to remove this warning. See\\n"}
-  {"event":"cmd_output",   "timestamp":"*", "output":"https://docs.docker.com/engine/reference/commandline/login/#credentials-store\\n"}
+  {"event":"cmd_output",   "timestamp":"*", "output":"https://docs.docker.com/engine/reference/commandline/login/#credential-stores\\n"}
   {"event":"cmd_output",   "timestamp":"*", "output":"\\n"}
   {"event":"cmd_output",   "timestamp":"*", "output":"Login Succeeded\\n"}
   {"event":"cmd_output",   "timestamp":"*", "output":"\\n"}

--- a/test/e2e/docker/docker_private_image_ecr_v2.rb
+++ b/test/e2e/docker/docker_private_image_ecr_v2.rb
@@ -64,7 +64,7 @@ assert_job_log <<-LOG
   {"event":"cmd_output",   "timestamp":"*", "output":"aws ecr get-login-password --region $AWS_REGION | docker login --username AWS --password-stdin #{aws_account_id}.dkr.ecr.$AWS_REGION.amazonaws.com\\n"}
   {"event":"cmd_output",   "timestamp":"*", "output":"WARNING! Your password will be stored unencrypted in /root/.docker/config.json.\\n"}
   {"event":"cmd_output",   "timestamp":"*", "output":"Configure a credential helper to remove this warning. See\\n"}
-  {"event":"cmd_output",   "timestamp":"*", "output":"https://docs.docker.com/engine/reference/commandline/login/#credentials-store\\n"}
+  {"event":"cmd_output",   "timestamp":"*", "output":"https://docs.docker.com/engine/reference/commandline/login/#credential-stores\\n"}
   {"event":"cmd_output",   "timestamp":"*", "output":"\\n"}
   {"event":"cmd_output",   "timestamp":"*", "output":"Login Succeeded\\n"}
   {"event":"cmd_output",   "timestamp":"*", "output":"\\n"}

--- a/test/e2e/docker/docker_private_image_gcr.rb
+++ b/test/e2e/docker/docker_private_image_gcr.rb
@@ -57,7 +57,7 @@ assert_job_log <<-LOG
   {"event":"cmd_output","output":"cat /tmp/gcr/keyfile.json | docker login -u _json_key --password-stdin https://$GCR_HOSTNAME\\n","timestamp":"*"}
   {"event":"cmd_output","output":"WARNING! Your password will be stored unencrypted in /root/.docker/config.json.\\n","timestamp":"*"}
   {"event":"cmd_output","output":"Configure a credential helper to remove this warning. See\\n","timestamp":"*"}
-  {"event":"cmd_output","output":"https://docs.docker.com/engine/reference/commandline/login/#credentials-store\\n","timestamp":"*"}
+  {"event":"cmd_output","output":"https://docs.docker.com/engine/reference/commandline/login/#credential-stores\\n","timestamp":"*"}
   {"event":"cmd_output","output":"\\n","timestamp":"*"}
   {"event":"cmd_output","output":"Login Succeeded\\n","timestamp":"*"}
   {"event":"cmd_output","output":"\\n","timestamp":"*"}

--- a/test/e2e/docker/docker_registry_private_image.rb
+++ b/test/e2e/docker/docker_registry_private_image.rb
@@ -58,7 +58,7 @@ assert_job_log <<-LOG
   {"event":"cmd_output",   "timestamp":"*", "output":"WARNING! Using --password via the CLI is insecure. Use --password-stdin.\\n"}
   {"event":"cmd_output",   "timestamp":"*", "output":"WARNING! Your password will be stored unencrypted in /root/.docker/config.json.\\n"}
   {"event":"cmd_output",   "timestamp":"*", "output":"Configure a credential helper to remove this warning. See\\n"}
-  {"event":"cmd_output",   "timestamp":"*", "output":"https://docs.docker.com/engine/reference/commandline/login/#credentials-store\\n"}
+  {"event":"cmd_output",   "timestamp":"*", "output":"https://docs.docker.com/engine/reference/commandline/login/#credential-stores\\n"}
   {"event":"cmd_output",   "timestamp":"*", "output":"\\n"}
   {"event":"cmd_output",   "timestamp":"*", "output":"Login Succeeded\\n"}
   {"event":"cmd_output",   "timestamp":"*", "output":"\\n"}

--- a/test/e2e/docker/dockerhub_private_image.rb
+++ b/test/e2e/docker/dockerhub_private_image.rb
@@ -56,7 +56,7 @@ assert_job_log <<-LOG
   {"event":"cmd_output",   "timestamp":"*", "output":"echo $DOCKERHUB_PASSWORD | docker login --username $DOCKERHUB_USERNAME --password-stdin\\n"}
   {"event":"cmd_output",   "timestamp":"*", "output":"WARNING! Your password will be stored unencrypted in /root/.docker/config.json.\\n"}
   {"event":"cmd_output",   "timestamp":"*", "output":"Configure a credential helper to remove this warning. See\\n"}
-  {"event":"cmd_output",   "timestamp":"*", "output":"https://docs.docker.com/engine/reference/commandline/login/#credentials-store\\n"}
+  {"event":"cmd_output",   "timestamp":"*", "output":"https://docs.docker.com/engine/reference/commandline/login/#credential-stores\\n"}
   {"event":"cmd_output",   "timestamp":"*", "output":"\\n"}
   {"event":"cmd_output",   "timestamp":"*", "output":"Login Succeeded\\n"}
   {"event":"cmd_output",   "timestamp":"*", "output":"\\n"}

--- a/test/e2e/docker/dockerhub_private_image.rb
+++ b/test/e2e/docker/dockerhub_private_image.rb
@@ -21,8 +21,8 @@ start_job <<-JSON
         {
           "env_vars": [
             { "name": "DOCKER_CREDENTIAL_TYPE", "value": "#{Base64.strict_encode64("DockerHub")}" },
-            { "name": "DOCKERHUB_USERNAME", "value": "#{Base64.strict_encode64("semaphoreagentprivatepuller")}" },
-            { "name": "DOCKERHUB_PASSWORD", "value": "#{Base64.strict_encode64("semaphoreagentprivatepullerpassword")}" }
+            { "name": "DOCKERHUB_USERNAME", "value": "#{Base64.strict_encode64(ENV['DOCKERHUB_USERNAME'])}" },
+            { "name": "DOCKERHUB_PASSWORD", "value": "#{Base64.strict_encode64(ENV['DOCKERHUB_TOKEN'])}" }
           ]
         }
       ]


### PR DESCRIPTION
https://github.com/renderedtext/tasks/issues/6471

### Details

Currently, the cloud agent will retry sending the job finished callback 60 times, with a 1s wait before each attempt, meaning it will retry for 1 minute. We should make that retrying window wider, so I'm increasing it to 5 minutes, and also adding a `--callback-retry-attempts` option to make it configurable.