### PR TITLE
feat: set User-Agent HTTP header on requests

### DIFF
--- a/main.go
+++ b/main.go
@@ -29,7 +29,7 @@ import (
 )
 
 var VERSION = "dev"
-var HTTP_USER_AGENT = fmt.Sprintf("SemaphoreAgent/%s", VERSION)
+var HTTPUserAgent = fmt.Sprintf("SemaphoreAgent/%s", VERSION)
 
 func main() {
 	logfile := OpenLogfile()
@@ -221,7 +221,7 @@ func RunListener(httpClient *http.Client, logfile io.Writer) {
 		FailOnPreJobHookError:            viper.GetBool(config.FailOnPreJobHookError),
 		SourcePreJobHook:                 viper.GetBool(config.SourcePreJobHook),
 		AgentVersion:                     VERSION,
-		UserAgent:                        HTTP_USER_AGENT,
+		UserAgent:                        HTTPUserAgent,
 		ExitOnShutdown:                   true,
 		KubernetesExecutor:               viper.GetBool(config.KubernetesExecutor),
 		KubernetesPodSpec:                viper.GetString(config.KubernetesPodSpec),
@@ -400,7 +400,7 @@ func RunServer(httpClient *http.Client, logfile io.Writer) {
 	server.NewServer(server.ServerConfig{
 		Host:                  *host,
 		Port:                  *port,
-		UserAgent:             HTTP_USER_AGENT,
+		UserAgent:             HTTPUserAgent,
 		TLSCertPath:           *tlsCertPath,
 		TLSKeyPath:            *tlsKeyPath,
 		Version:               VERSION,

--- a/main.go
+++ b/main.go
@@ -29,6 +29,7 @@ import (
 )
 
 var VERSION = "dev"
+var HTTP_USER_AGENT = fmt.Sprintf("SemaphoreAgent/%s", VERSION)
 
 func main() {
 	logfile := OpenLogfile()
@@ -220,6 +221,7 @@ func RunListener(httpClient *http.Client, logfile io.Writer) {
 		FailOnPreJobHookError:            viper.GetBool(config.FailOnPreJobHookError),
 		SourcePreJobHook:                 viper.GetBool(config.SourcePreJobHook),
 		AgentVersion:                     VERSION,
+		UserAgent:                        HTTP_USER_AGENT,
 		ExitOnShutdown:                   true,
 		KubernetesExecutor:               viper.GetBool(config.KubernetesExecutor),
 		KubernetesPodSpec:                viper.GetString(config.KubernetesPodSpec),
@@ -398,6 +400,7 @@ func RunServer(httpClient *http.Client, logfile io.Writer) {
 	server.NewServer(server.ServerConfig{
 		Host:                  *host,
 		Port:                  *port,
+		UserAgent:             HTTP_USER_AGENT,
 		TLSCertPath:           *tlsCertPath,
 		TLSKeyPath:            *tlsKeyPath,
 		Version:               VERSION,

--- a/pkg/eventlogger/httpbackend.go
+++ b/pkg/eventlogger/httpbackend.go
@@ -34,6 +34,7 @@ type HTTPBackend struct {
 
 type HTTPBackendConfig struct {
 	URL                   string
+	UserAgent             string
 	Token                 string
 	LinesPerRequest       int
 	FlushTimeoutInSeconds int
@@ -179,6 +180,7 @@ func (l *HTTPBackend) newRequest() error {
 
 	request.Header.Set("Content-Type", "text/plain")
 	request.Header.Set("Authorization", fmt.Sprintf("Bearer %s", l.config.Token))
+	request.Header.Set("User-Agent", l.config.UserAgent)
 	response, err := l.client.Do(request)
 	if err != nil {
 		return err

--- a/pkg/eventlogger/httpbackend_test.go
+++ b/pkg/eventlogger/httpbackend_test.go
@@ -1,6 +1,7 @@
 package eventlogger
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -93,6 +94,7 @@ func Test__LogsArePushedToHTTPEndpoint(t *testing.T) {
 		RefreshTokenFn:        func() (string, error) { return "", nil },
 		LinesPerRequest:       20,
 		FlushTimeoutInSeconds: DefaultFlushTimeoutInSeconds,
+		UserAgent:             fmt.Sprintf("SemaphoreAgent/%s", testsupport.AgentVersionExpected),
 	})
 
 	assert.Nil(t, err)
@@ -132,6 +134,7 @@ func Test__RequestsAreCappedAtLinesPerRequest(t *testing.T) {
 		RefreshTokenFn:        func() (string, error) { return "", nil },
 		LinesPerRequest:       2,
 		FlushTimeoutInSeconds: DefaultFlushTimeoutInSeconds,
+		UserAgent:             fmt.Sprintf("SemaphoreAgent/%s", testsupport.AgentVersionExpected),
 	})
 
 	assert.Nil(t, err)
@@ -183,6 +186,7 @@ func Test__FlushingGivesUpAfterTimeout(t *testing.T) {
 		RefreshTokenFn:        func() (string, error) { return "", nil },
 		LinesPerRequest:       2,
 		FlushTimeoutInSeconds: 10,
+		UserAgent:             fmt.Sprintf("SemaphoreAgent/%s", testsupport.AgentVersionExpected),
 	})
 
 	assert.Nil(t, err)
@@ -217,6 +221,7 @@ func Test__ExecutesOnCloseCallback(t *testing.T) {
 		RefreshTokenFn:        func() (string, error) { return "", nil },
 		LinesPerRequest:       10,
 		FlushTimeoutInSeconds: 10,
+		UserAgent:             fmt.Sprintf("SemaphoreAgent/%s", testsupport.AgentVersionExpected),
 	})
 
 	assert.Nil(t, err)
@@ -246,6 +251,7 @@ func Test__TokenIsRefreshed(t *testing.T) {
 		Token:                 testsupport.ExpiredLogToken,
 		LinesPerRequest:       20,
 		FlushTimeoutInSeconds: DefaultFlushTimeoutInSeconds,
+		UserAgent:             fmt.Sprintf("SemaphoreAgent/%s", testsupport.AgentVersionExpected),
 		RefreshTokenFn: func() (string, error) {
 			tokenWasRefreshed = true
 			return "some-new-and-shiny-valid-token", nil

--- a/pkg/jobs/job.go
+++ b/pkg/jobs/job.go
@@ -37,6 +37,7 @@ type Job struct {
 	Stopped        bool
 	Finished       bool
 	UploadJobLogs  string
+	UserAgent      string
 }
 
 type JobOptions struct {
@@ -54,6 +55,7 @@ type JobOptions struct {
 	KubernetesImageValidator         *kubernetes.ImageValidator
 	UploadJobLogs                    string
 	RefreshTokenFn                   func() (string, error)
+	UserAgent                        string
 }
 
 func NewJob(request *api.JobRequest, client *http.Client) (*Job, error) {
@@ -90,7 +92,12 @@ func NewJobWithOptions(options *JobOptions) (*Job, error) {
 	if options.Logger != nil {
 		job.Logger = options.Logger
 	} else {
-		l, err := eventlogger.CreateLogger(options.Request, options.RefreshTokenFn)
+		l, err := eventlogger.CreateLogger(eventlogger.LoggerOptions{
+			Request:        options.Request,
+			RefreshTokenFn: options.RefreshTokenFn,
+			UserAgent:      options.UserAgent,
+		})
+
 		if err != nil {
 			return nil, err
 		}
@@ -641,6 +648,7 @@ func (job *Job) SendCallback(url string, payload string) error {
 		request.Header.Set("Authorization", fmt.Sprintf("Bearer %s", job.Request.Callbacks.Token))
 	}
 
+	request.Header.Set("User-Agent", job.UserAgent)
 	response, err := job.Client.Do(request)
 	if err != nil {
 		return err

--- a/pkg/listener/job_processor.go
+++ b/pkg/listener/job_processor.go
@@ -26,6 +26,7 @@ func StartJobProcessor(httpClient *http.Client, apiClient *selfhostedapi.API, co
 	p := &JobProcessor{
 		HTTPClient:                       httpClient,
 		APIClient:                        apiClient,
+		UserAgent:                        config.UserAgent,
 		LastSuccessfulSync:               time.Now(),
 		forceSyncCh:                      make(chan bool),
 		State:                            selfhostedapi.AgentStateWaitingForJobs,
@@ -84,6 +85,7 @@ type JobProcessor struct {
 	FileInjections                   []config.FileInjection
 	FailOnMissingFiles               bool
 	UploadJobLogs                    string
+	UserAgent                        string
 	FailOnPreJobHookError            bool
 	SourcePreJobHook                 bool
 	ExitOnShutdown                   bool
@@ -211,6 +213,7 @@ func (p *JobProcessor) RunJob(jobID string) {
 		KubernetesLabels:                 p.KubernetesLabels,
 		KubernetesImageValidator:         p.KubernetesImageValidator,
 		UploadJobLogs:                    p.UploadJobLogs,
+		UserAgent:                        p.UserAgent,
 		RefreshTokenFn: func() (string, error) {
 			return p.APIClient.RefreshToken()
 		},

--- a/pkg/listener/listener.go
+++ b/pkg/listener/listener.go
@@ -55,7 +55,7 @@ type Config struct {
 func Start(httpClient *http.Client, config Config) (*Listener, error) {
 	listener := &Listener{
 		Config: config,
-		Client: selfhostedapi.New(httpClient, config.Scheme, config.Endpoint, config.Token),
+		Client: selfhostedapi.New(httpClient, config.Scheme, config.Endpoint, config.Token, config.AgentVersion),
 	}
 
 	listener.DisplayHelloMessage()

--- a/pkg/listener/listener.go
+++ b/pkg/listener/listener.go
@@ -44,6 +44,7 @@ type Config struct {
 	SourcePreJobHook                 bool
 	ExitOnShutdown                   bool
 	AgentVersion                     string
+	UserAgent                        string
 	AgentName                        string
 	KubernetesExecutor               bool
 	KubernetesPodSpec                string
@@ -55,7 +56,7 @@ type Config struct {
 func Start(httpClient *http.Client, config Config) (*Listener, error) {
 	listener := &Listener{
 		Config: config,
-		Client: selfhostedapi.New(httpClient, config.Scheme, config.Endpoint, config.Token, config.AgentVersion),
+		Client: selfhostedapi.New(httpClient, config.Scheme, config.Endpoint, config.Token, config.UserAgent),
 	}
 
 	listener.DisplayHelloMessage()

--- a/pkg/listener/listener_test.go
+++ b/pkg/listener/listener_test.go
@@ -38,6 +38,7 @@ func Test__Register(t *testing.T) {
 		EnvVars:            []config.HostEnvVar{},
 		FileInjections:     []config.FileInjection{},
 		AgentVersion:       testsupport.AgentVersionExpected,
+		UserAgent:          fmt.Sprintf("SemaphoreAgent/%s", testsupport.AgentVersionExpected),
 	}
 
 	listener, err := Start(http.DefaultClient, config)
@@ -79,6 +80,7 @@ func Test__RegisterRequestIsRetried(t *testing.T) {
 		EnvVars:            []config.HostEnvVar{},
 		FileInjections:     []config.FileInjection{},
 		AgentVersion:       testsupport.AgentVersionExpected,
+		UserAgent:          fmt.Sprintf("SemaphoreAgent/%s", testsupport.AgentVersionExpected),
 	}
 
 	listener, err := Start(http.DefaultClient, config)
@@ -121,6 +123,7 @@ func Test__RegistrationFails(t *testing.T) {
 		EnvVars:            []config.HostEnvVar{},
 		FileInjections:     []config.FileInjection{},
 		AgentVersion:       testsupport.AgentVersionExpected,
+		UserAgent:          fmt.Sprintf("SemaphoreAgent/%s", testsupport.AgentVersionExpected),
 	}
 
 	_, err := Start(http.DefaultClient, config)
@@ -164,6 +167,7 @@ func Test__ShutdownHookIsExecuted(t *testing.T) {
 		EnvVars:            []config.HostEnvVar{},
 		FileInjections:     []config.FileInjection{},
 		AgentVersion:       testsupport.AgentVersionExpected,
+		UserAgent:          fmt.Sprintf("SemaphoreAgent/%s", testsupport.AgentVersionExpected),
 		ShutdownHookPath:   hook,
 	}
 
@@ -217,6 +221,7 @@ func Test__ShutdownHookCanSeeShutdownReason(t *testing.T) {
 		FileInjections:     []config.FileInjection{},
 		UploadJobLogs:      config.UploadJobLogsConditionNever,
 		AgentVersion:       testsupport.AgentVersionExpected,
+		UserAgent:          fmt.Sprintf("SemaphoreAgent/%s", testsupport.AgentVersionExpected),
 		ShutdownHookPath:   hook,
 	}
 
@@ -264,6 +269,7 @@ func Test__ShutdownAfterJobFinished(t *testing.T) {
 		FileInjections:     []config.FileInjection{},
 		UploadJobLogs:      config.UploadJobLogsConditionNever,
 		AgentVersion:       testsupport.AgentVersionExpected,
+		UserAgent:          fmt.Sprintf("SemaphoreAgent/%s", testsupport.AgentVersionExpected),
 	}
 
 	listener, err := Start(http.DefaultClient, config)
@@ -314,6 +320,7 @@ func Test__ShutdownAfterIdleTimeout(t *testing.T) {
 		FileInjections:             []config.FileInjection{},
 		UploadJobLogs:              config.UploadJobLogsConditionNever,
 		AgentVersion:               testsupport.AgentVersionExpected,
+		UserAgent:                  fmt.Sprintf("SemaphoreAgent/%s", testsupport.AgentVersionExpected),
 	}
 
 	listener, err := Start(http.DefaultClient, config)
@@ -346,6 +353,7 @@ func Test__ShutdownAfterInterruption(t *testing.T) {
 		FileInjections:     []config.FileInjection{},
 		UploadJobLogs:      config.UploadJobLogsConditionNever,
 		AgentVersion:       testsupport.AgentVersionExpected,
+		UserAgent:          fmt.Sprintf("SemaphoreAgent/%s", testsupport.AgentVersionExpected),
 	}
 
 	listener, err := Start(http.DefaultClient, config)
@@ -381,6 +389,7 @@ func Test__ShutdownAfterInterruptionNoGracePeriod(t *testing.T) {
 		FileInjections:     []config.FileInjection{},
 		UploadJobLogs:      config.UploadJobLogsConditionNever,
 		AgentVersion:       testsupport.AgentVersionExpected,
+		UserAgent:          fmt.Sprintf("SemaphoreAgent/%s", testsupport.AgentVersionExpected),
 	}
 
 	listener, err := Start(http.DefaultClient, config)
@@ -438,6 +447,7 @@ func Test__ShutdownAfterInterruptionWithGracePeriod(t *testing.T) {
 		EnvVars:                 []config.HostEnvVar{},
 		FileInjections:          []config.FileInjection{},
 		AgentVersion:            testsupport.AgentVersionExpected,
+		UserAgent:               fmt.Sprintf("SemaphoreAgent/%s", testsupport.AgentVersionExpected),
 		UploadJobLogs:           config.UploadJobLogsConditionNever,
 		InterruptionGracePeriod: 30,
 	}
@@ -497,6 +507,7 @@ func Test__ShutdownFromUpstreamWhileWaiting(t *testing.T) {
 		FileInjections:     []config.FileInjection{},
 		UploadJobLogs:      config.UploadJobLogsConditionNever,
 		AgentVersion:       testsupport.AgentVersionExpected,
+		UserAgent:          fmt.Sprintf("SemaphoreAgent/%s", testsupport.AgentVersionExpected),
 	}
 
 	listener, err := Start(http.DefaultClient, config)
@@ -533,6 +544,7 @@ func Test__ShutdownFromUpstreamWhileRunningJob(t *testing.T) {
 		FileInjections:     []config.FileInjection{},
 		UploadJobLogs:      config.UploadJobLogsConditionNever,
 		AgentVersion:       testsupport.AgentVersionExpected,
+		UserAgent:          fmt.Sprintf("SemaphoreAgent/%s", testsupport.AgentVersionExpected),
 	}
 
 	listener, err := Start(http.DefaultClient, config)
@@ -588,6 +600,7 @@ func Test__HostEnvVarsAreExposedToJob(t *testing.T) {
 		FileInjections: []config.FileInjection{},
 		UploadJobLogs:  config.UploadJobLogsConditionNever,
 		AgentVersion:   testsupport.AgentVersionExpected,
+		UserAgent:      fmt.Sprintf("SemaphoreAgent/%s", testsupport.AgentVersionExpected),
 	}
 
 	listener, err := Start(http.DefaultClient, config)
@@ -721,6 +734,7 @@ func Test__LogTokenIsRefreshed(t *testing.T) {
 		FileInjections:     []config.FileInjection{},
 		UploadJobLogs:      config.UploadJobLogsConditionNever,
 		AgentVersion:       testsupport.AgentVersionExpected,
+		UserAgent:          fmt.Sprintf("SemaphoreAgent/%s", testsupport.AgentVersionExpected),
 	}
 
 	listener, err := Start(http.DefaultClient, config)
@@ -801,6 +815,7 @@ func Test__GetJobIsRetried(t *testing.T) {
 		FileInjections:     []config.FileInjection{},
 		UploadJobLogs:      config.UploadJobLogsConditionNever,
 		AgentVersion:       testsupport.AgentVersionExpected,
+		UserAgent:          fmt.Sprintf("SemaphoreAgent/%s", testsupport.AgentVersionExpected),
 	}
 
 	listener, err := Start(http.DefaultClient, config)
@@ -854,6 +869,7 @@ func Test__ReportsFailedToFetchJob(t *testing.T) {
 		FileInjections:     []config.FileInjection{},
 		UploadJobLogs:      config.UploadJobLogsConditionNever,
 		AgentVersion:       testsupport.AgentVersionExpected,
+		UserAgent:          fmt.Sprintf("SemaphoreAgent/%s", testsupport.AgentVersionExpected),
 	}
 
 	listener, err := Start(http.DefaultClient, config)
@@ -904,6 +920,7 @@ func Test__ReportsFailedToConstructJob(t *testing.T) {
 		FileInjections:     []config.FileInjection{},
 		UploadJobLogs:      config.UploadJobLogsConditionNever,
 		AgentVersion:       testsupport.AgentVersionExpected,
+		UserAgent:          fmt.Sprintf("SemaphoreAgent/%s", testsupport.AgentVersionExpected),
 	}
 
 	listener, err := Start(http.DefaultClient, config)

--- a/pkg/listener/listener_test.go
+++ b/pkg/listener/listener_test.go
@@ -37,7 +37,7 @@ func Test__Register(t *testing.T) {
 		Scheme:             "http",
 		EnvVars:            []config.HostEnvVar{},
 		FileInjections:     []config.FileInjection{},
-		AgentVersion:       "0.0.7",
+		AgentVersion:       testsupport.AgentVersionExpected,
 	}
 
 	listener, err := Start(http.DefaultClient, config)
@@ -50,7 +50,7 @@ func Test__Register(t *testing.T) {
 		assert.NotEmpty(t, registerRequest.Name)
 		assert.NotEmpty(t, registerRequest.OS)
 		assert.NotZero(t, registerRequest.PID)
-		assert.Equal(t, registerRequest.Version, "0.0.7")
+		assert.Equal(t, registerRequest.Version, testsupport.AgentVersionExpected)
 	}
 
 	listener.Stop()
@@ -78,7 +78,7 @@ func Test__RegisterRequestIsRetried(t *testing.T) {
 		Scheme:             "http",
 		EnvVars:            []config.HostEnvVar{},
 		FileInjections:     []config.FileInjection{},
-		AgentVersion:       "0.0.7",
+		AgentVersion:       testsupport.AgentVersionExpected,
 	}
 
 	listener, err := Start(http.DefaultClient, config)
@@ -92,7 +92,7 @@ func Test__RegisterRequestIsRetried(t *testing.T) {
 		assert.NotEmpty(t, registerRequest.Name)
 		assert.NotEmpty(t, registerRequest.OS)
 		assert.NotZero(t, registerRequest.PID)
-		assert.Equal(t, registerRequest.Version, "0.0.7")
+		assert.Equal(t, registerRequest.Version, testsupport.AgentVersionExpected)
 	}
 
 	listener.Stop()
@@ -120,7 +120,7 @@ func Test__RegistrationFails(t *testing.T) {
 		Scheme:             "http",
 		EnvVars:            []config.HostEnvVar{},
 		FileInjections:     []config.FileInjection{},
-		AgentVersion:       "0.0.7",
+		AgentVersion:       testsupport.AgentVersionExpected,
 	}
 
 	_, err := Start(http.DefaultClient, config)
@@ -163,7 +163,7 @@ func Test__ShutdownHookIsExecuted(t *testing.T) {
 		Scheme:             "http",
 		EnvVars:            []config.HostEnvVar{},
 		FileInjections:     []config.FileInjection{},
-		AgentVersion:       "0.0.7",
+		AgentVersion:       testsupport.AgentVersionExpected,
 		ShutdownHookPath:   hook,
 	}
 
@@ -216,7 +216,7 @@ func Test__ShutdownHookCanSeeShutdownReason(t *testing.T) {
 		EnvVars:            []config.HostEnvVar{},
 		FileInjections:     []config.FileInjection{},
 		UploadJobLogs:      config.UploadJobLogsConditionNever,
-		AgentVersion:       "0.0.7",
+		AgentVersion:       testsupport.AgentVersionExpected,
 		ShutdownHookPath:   hook,
 	}
 
@@ -263,7 +263,7 @@ func Test__ShutdownAfterJobFinished(t *testing.T) {
 		EnvVars:            []config.HostEnvVar{},
 		FileInjections:     []config.FileInjection{},
 		UploadJobLogs:      config.UploadJobLogsConditionNever,
-		AgentVersion:       "0.0.7",
+		AgentVersion:       testsupport.AgentVersionExpected,
 	}
 
 	listener, err := Start(http.DefaultClient, config)
@@ -313,7 +313,7 @@ func Test__ShutdownAfterIdleTimeout(t *testing.T) {
 		EnvVars:                    []config.HostEnvVar{},
 		FileInjections:             []config.FileInjection{},
 		UploadJobLogs:              config.UploadJobLogsConditionNever,
-		AgentVersion:               "0.0.7",
+		AgentVersion:               testsupport.AgentVersionExpected,
 	}
 
 	listener, err := Start(http.DefaultClient, config)
@@ -345,7 +345,7 @@ func Test__ShutdownAfterInterruption(t *testing.T) {
 		EnvVars:            []config.HostEnvVar{},
 		FileInjections:     []config.FileInjection{},
 		UploadJobLogs:      config.UploadJobLogsConditionNever,
-		AgentVersion:       "0.0.7",
+		AgentVersion:       testsupport.AgentVersionExpected,
 	}
 
 	listener, err := Start(http.DefaultClient, config)
@@ -380,7 +380,7 @@ func Test__ShutdownAfterInterruptionNoGracePeriod(t *testing.T) {
 		EnvVars:            []config.HostEnvVar{},
 		FileInjections:     []config.FileInjection{},
 		UploadJobLogs:      config.UploadJobLogsConditionNever,
-		AgentVersion:       "0.0.7",
+		AgentVersion:       testsupport.AgentVersionExpected,
 	}
 
 	listener, err := Start(http.DefaultClient, config)
@@ -437,7 +437,7 @@ func Test__ShutdownAfterInterruptionWithGracePeriod(t *testing.T) {
 		Scheme:                  "http",
 		EnvVars:                 []config.HostEnvVar{},
 		FileInjections:          []config.FileInjection{},
-		AgentVersion:            "0.0.7",
+		AgentVersion:            testsupport.AgentVersionExpected,
 		UploadJobLogs:           config.UploadJobLogsConditionNever,
 		InterruptionGracePeriod: 30,
 	}
@@ -496,7 +496,7 @@ func Test__ShutdownFromUpstreamWhileWaiting(t *testing.T) {
 		EnvVars:            []config.HostEnvVar{},
 		FileInjections:     []config.FileInjection{},
 		UploadJobLogs:      config.UploadJobLogsConditionNever,
-		AgentVersion:       "0.0.7",
+		AgentVersion:       testsupport.AgentVersionExpected,
 	}
 
 	listener, err := Start(http.DefaultClient, config)
@@ -532,7 +532,7 @@ func Test__ShutdownFromUpstreamWhileRunningJob(t *testing.T) {
 		EnvVars:            []config.HostEnvVar{},
 		FileInjections:     []config.FileInjection{},
 		UploadJobLogs:      config.UploadJobLogsConditionNever,
-		AgentVersion:       "0.0.7",
+		AgentVersion:       testsupport.AgentVersionExpected,
 	}
 
 	listener, err := Start(http.DefaultClient, config)
@@ -587,7 +587,7 @@ func Test__HostEnvVarsAreExposedToJob(t *testing.T) {
 		},
 		FileInjections: []config.FileInjection{},
 		UploadJobLogs:  config.UploadJobLogsConditionNever,
-		AgentVersion:   "0.0.7",
+		AgentVersion:   testsupport.AgentVersionExpected,
 	}
 
 	listener, err := Start(http.DefaultClient, config)
@@ -720,7 +720,7 @@ func Test__LogTokenIsRefreshed(t *testing.T) {
 		EnvVars:            []config.HostEnvVar{},
 		FileInjections:     []config.FileInjection{},
 		UploadJobLogs:      config.UploadJobLogsConditionNever,
-		AgentVersion:       "0.0.7",
+		AgentVersion:       testsupport.AgentVersionExpected,
 	}
 
 	listener, err := Start(http.DefaultClient, config)
@@ -800,7 +800,7 @@ func Test__GetJobIsRetried(t *testing.T) {
 		EnvVars:            []config.HostEnvVar{},
 		FileInjections:     []config.FileInjection{},
 		UploadJobLogs:      config.UploadJobLogsConditionNever,
-		AgentVersion:       "0.0.7",
+		AgentVersion:       testsupport.AgentVersionExpected,
 	}
 
 	listener, err := Start(http.DefaultClient, config)
@@ -853,7 +853,7 @@ func Test__ReportsFailedToFetchJob(t *testing.T) {
 		EnvVars:            []config.HostEnvVar{},
 		FileInjections:     []config.FileInjection{},
 		UploadJobLogs:      config.UploadJobLogsConditionNever,
-		AgentVersion:       "0.0.7",
+		AgentVersion:       testsupport.AgentVersionExpected,
 	}
 
 	listener, err := Start(http.DefaultClient, config)
@@ -903,7 +903,7 @@ func Test__ReportsFailedToConstructJob(t *testing.T) {
 		EnvVars:            []config.HostEnvVar{},
 		FileInjections:     []config.FileInjection{},
 		UploadJobLogs:      config.UploadJobLogsConditionNever,
-		AgentVersion:       "0.0.7",
+		AgentVersion:       testsupport.AgentVersionExpected,
 	}
 
 	listener, err := Start(http.DefaultClient, config)

--- a/pkg/listener/selfhostedapi/api.go
+++ b/pkg/listener/selfhostedapi/api.go
@@ -6,8 +6,9 @@ import (
 )
 
 type API struct {
-	Endpoint string
-	Scheme   string
+	Endpoint  string
+	Scheme    string
+	UserAgent string
 
 	RegisterToken string
 	AccessToken   string
@@ -15,12 +16,13 @@ type API struct {
 	client *http.Client
 }
 
-func New(httpClient *http.Client, scheme string, endpoint string, token string) *API {
+func New(httpClient *http.Client, scheme string, endpoint string, token string, agentVersion string) *API {
 	return &API{
 		Endpoint:      endpoint,
 		RegisterToken: token,
 		Scheme:        scheme,
 		client:        httpClient,
+		UserAgent:     fmt.Sprintf("SemaphoreAgent/%s", agentVersion),
 	}
 }
 

--- a/pkg/listener/selfhostedapi/api.go
+++ b/pkg/listener/selfhostedapi/api.go
@@ -16,13 +16,13 @@ type API struct {
 	client *http.Client
 }
 
-func New(httpClient *http.Client, scheme string, endpoint string, token string, agentVersion string) *API {
+func New(httpClient *http.Client, scheme string, endpoint string, token string, userAgent string) *API {
 	return &API{
 		Endpoint:      endpoint,
 		RegisterToken: token,
 		Scheme:        scheme,
 		client:        httpClient,
-		UserAgent:     fmt.Sprintf("SemaphoreAgent/%s", agentVersion),
+		UserAgent:     userAgent,
 	}
 }
 

--- a/pkg/listener/selfhostedapi/disconnect.go
+++ b/pkg/listener/selfhostedapi/disconnect.go
@@ -17,6 +17,7 @@ func (a *API) Disconnect() (string, error) {
 	}
 
 	a.authorize(r, a.AccessToken)
+	r.Header.Set("User-Agent", a.UserAgent)
 
 	resp, err := a.client.Do(r)
 	if err != nil {

--- a/pkg/listener/selfhostedapi/get_job.go
+++ b/pkg/listener/selfhostedapi/get_job.go
@@ -20,6 +20,7 @@ func (a *API) GetJob(jobID string) (*api.JobRequest, error) {
 	}
 
 	a.authorize(r, a.AccessToken)
+	r.Header.Set("User-Agent", a.UserAgent)
 
 	resp, err := a.client.Do(r)
 	if err != nil {

--- a/pkg/listener/selfhostedapi/refresh_token.go
+++ b/pkg/listener/selfhostedapi/refresh_token.go
@@ -26,6 +26,7 @@ func (a *API) RefreshToken() (string, error) {
 	log.Info("Refreshing token for current job logs...")
 
 	a.authorize(r, a.AccessToken)
+	r.Header.Set("User-Agent", a.UserAgent)
 
 	resp, err := a.client.Do(r)
 	if err != nil {

--- a/pkg/listener/selfhostedapi/register.go
+++ b/pkg/listener/selfhostedapi/register.go
@@ -45,6 +45,7 @@ func (a *API) Register(req *RegisterRequest) (*RegisterResponse, error) {
 	}
 
 	a.authorize(r, a.RegisterToken)
+	r.Header.Set("User-Agent", a.UserAgent)
 
 	resp, err := a.client.Do(r)
 	if err != nil {

--- a/pkg/listener/selfhostedapi/sync.go
+++ b/pkg/listener/selfhostedapi/sync.go
@@ -67,6 +67,7 @@ func (a *API) Sync(req *SyncRequest) (*SyncResponse, error) {
 	}
 
 	a.authorize(r, a.AccessToken)
+	r.Header.Set("User-Agent", a.UserAgent)
 
 	resp, err := a.client.Do(r)
 	if err != nil {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -38,6 +38,7 @@ type Server struct {
 type ServerConfig struct {
 	Host                  string
 	Port                  int
+	UserAgent             string
 	TLSCertPath           string
 	TLSKeyPath            string
 	Version               string
@@ -259,6 +260,7 @@ func (s *Server) Run(w http.ResponseWriter, r *http.Request) {
 		SelfHosted:      false,
 		RefreshTokenFn:  nil,
 		UploadJobLogs:   s.resolveUploadJobsConfig(request),
+		UserAgent:       s.Config.UserAgent,
 	})
 
 	if err != nil {


### PR DESCRIPTION
https://github.com/renderedtext/tasks/issues/6557

We are not currently setting the User-Agent HTTP header on the HTTP requests made to the Semaphore control plane. This pull request changes that and includes that header in the:
- Requests to `/api/v1/self_hosted_agents` endpoints
- Requests to `/api/v1/logs` endpoint
- Job callback requests