### PR TITLE
feat: new --expose-kvm-device flag

### DIFF
--- a/.semaphore/release.yml
+++ b/.semaphore/release.yml
@@ -15,7 +15,7 @@ blocks:
         - name: dockerhub-write
       prologue:
         commands:
-          - sem-version go 1.22.3
+          - sem-version go 1.22.7
           - "export GOPATH=~/go"
           - "export PATH=/home/semaphore/go/bin:$PATH"
           - checkout

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -22,7 +22,7 @@ blocks:
 
       prologue:
         commands:
-          - sem-version go 1.22.3
+          - sem-version go 1.22.7
           - checkout
 
       jobs:
@@ -41,7 +41,7 @@ blocks:
           - checkout
           - mv ~/.ssh/security-toolbox ~/.ssh/id_rsa
           - sudo chmod 600 ~/.ssh/id_rsa
-          - sem-version go 1.22.3
+          - sem-version go 1.22.7
       jobs:
         - name: Check dependencies
           commands:
@@ -67,7 +67,7 @@ blocks:
 
       prologue:
         commands:
-          - sem-version go 1.22.3
+          - sem-version go 1.22.7
           - checkout
           - go version
           - go get
@@ -100,7 +100,7 @@ blocks:
 
       prologue:
         commands:
-          - sem-version go 1.22.3
+          - sem-version go 1.22.7
           - checkout
           - go version
           - go get
@@ -169,7 +169,7 @@ blocks:
 
       prologue:
         commands:
-          - sem-version go 1.22.3
+          - sem-version go 1.22.7
           - checkout
           - go version
           - go get
@@ -205,7 +205,7 @@ blocks:
 
       prologue:
         commands:
-          - sem-version go 1.22.3
+          - sem-version go 1.22.7
           - checkout
           - go version
           - go get
@@ -246,7 +246,7 @@ blocks:
 
       prologue:
         commands:
-          - sem-version go 1.22.3
+          - sem-version go 1.22.7
           - curl -sLO https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64 && install minikube-linux-amd64 /tmp/
           - /tmp/minikube-linux-amd64 config set WantUpdateNotification false
           - /tmp/minikube-linux-amd64 start --driver=docker

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ check.docker: check.prepare
 		-v $(SECURITY_TOOLBOX_TMP_DIR):$(SECURITY_TOOLBOX_TMP_DIR) \
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		registry.semaphoreci.com/ruby:2.7 \
-		bash -c 'cd /app && $(SECURITY_TOOLBOX_TMP_DIR)/docker -d --image semaphoreci/agent:latest --skip-files Dockerfile.ecr,Dockerfile.test,Dockerfile.dev,test/hub_reference/Dockerfile,Dockerfile.empty_ubuntu'
+		bash -c 'cd /app && $(SECURITY_TOOLBOX_TMP_DIR)/docker -d --image semaphoreci/agent:latest --skip-files Dockerfile.ecr,Dockerfile.test,Dockerfile.dev,test/hub_reference/Dockerfile,Dockerfile.empty_ubuntu,/usr/local/bin/kubectl'
 
 lint:
 	revive -formatter friendly -config lint.toml ./...

--- a/go.mod
+++ b/go.mod
@@ -77,4 +77,4 @@ require (
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
 
-go 1.22.4
+go 1.22.7

--- a/main.go
+++ b/main.go
@@ -375,6 +375,7 @@ func RunServer(httpClient *http.Client, logfile io.Writer) {
 	callbackRetryAttempts := pflag.Int("callback-retry-attempts", server.DefaultCallbackRetryAttempts, "Number of times to retry sending the callback after the job is finished")
 	preJobHookPath := pflag.String(config.PreJobHookPath, "", "The path to a pre-job hook script")
 	files := pflag.StringSlice(config.Files, []string{}, "Inject files into container, when using docker compose executor")
+	exposeKvmDevice := pflag.Bool(config.ExposeKvmDevice, true, "Expose /dev/kvm device, when using docker compose executor")
 
 	pflag.Parse()
 
@@ -410,6 +411,7 @@ func RunServer(httpClient *http.Client, logfile io.Writer) {
 		PreJobHookPath:        *preJobHookPath,
 		FileInjections:        fileInjections,
 		CallbackRetryAttempts: *callbackRetryAttempts,
+		ExposeKvmDevice:       *exposeKvmDevice,
 	}).Serve()
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -17,6 +17,7 @@ const (
 	DisconnectAfterIdleTimeout = "disconnect-after-idle-timeout"
 	EnvVars                    = "env-vars"
 	Files                      = "files"
+	ExposeKvmDevice            = "expose-kvm-device"
 	FailOnMissingFiles         = "fail-on-missing-files"
 	UploadJobLogs              = "upload-job-logs"
 	FailOnPreJobHookError      = "fail-on-pre-job-hook-error"

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -48,6 +48,7 @@ type ServerConfig struct {
 	PreJobHookPath        string
 	FileInjections        []config.FileInjection
 	CallbackRetryAttempts int
+	ExposeKvmDevice       bool
 
 	// A way to execute some code before handling a POST /jobs request.
 	// Currently, only used to make tests that assert race condition scenarios more reproducible.
@@ -255,7 +256,7 @@ func (s *Server) Run(w http.ResponseWriter, r *http.Request) {
 	job, err := jobs.NewJobWithOptions(&jobs.JobOptions{
 		Request:         request,
 		Client:          s.HTTPClient,
-		ExposeKvmDevice: true,
+		ExposeKvmDevice: s.Config.ExposeKvmDevice,
 		FileInjections:  s.Config.FileInjections,
 		SelfHosted:      false,
 		RefreshTokenFn:  nil,


### PR DESCRIPTION
https://github.com/renderedtext/tasks/issues/6702

For agent serve and docker-compose jobs, we always add a `/dev/kvm` device in the docker compose YAML for the job. We should make that configurable, since not all environments have that device available. For that, we add a new `--expose-kvm-flag`.

### Other changes

- Update Go to 1.22.7 due to vulnerability
- Ignore kubectl when scanning Docker image
