### PR TITLE
fix: expose temp file with environment variables in Windows

### DIFF
--- a/pkg/kubernetes/client_test.go
+++ b/pkg/kubernetes/client_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	stdruntime "runtime"
 	"testing"
 	"time"
 
@@ -12,7 +13,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 )
@@ -40,9 +41,16 @@ func Test__CreateSecret(t *testing.T) {
 		assert.True(t, *secret.Immutable)
 		assert.Equal(t, secret.Name, secretName)
 		assert.Empty(t, secret.Labels)
-		assert.Equal(t, secret.StringData, map[string]string{
-			".env": "export A=AAA\nexport B=BBB\nexport C=CCC\n",
-		})
+
+		if stdruntime.GOOS == "windows" {
+			assert.Equal(t, secret.StringData, map[string]string{
+				".env": `$env:A = "AAA"\n$env:B = "BBB"\n$env:C = "CCC"\n`,
+			})
+		} else {
+			assert.Equal(t, secret.StringData, map[string]string{
+				".env": "export A=AAA\nexport B=BBB\nexport C=CCC\n",
+			})
+		}
 	})
 
 	t.Run("stores files in secret, with base64-encoded keys", func(t *testing.T) {
@@ -82,11 +90,20 @@ func Test__CreateSecret(t *testing.T) {
 		assert.True(t, *secret.Immutable)
 		assert.Equal(t, secret.Name, secretName)
 		assert.Empty(t, secret.Labels)
-		assert.Equal(t, secret.StringData, map[string]string{
-			".env": "export A=AAA\nexport B=BBB\nexport C=CCC\n",
-			key1:   "Random content",
-			key2:   "Random content 2",
-		})
+
+		if stdruntime.GOOS == "windows" {
+			assert.Equal(t, secret.StringData, map[string]string{
+				".env": `$env:A = "AAA"\n$env:B = "BBB"\n$env:C = "CCC"\n`,
+				key1:   "Random content",
+				key2:   "Random content 2",
+			})
+		} else {
+			assert.Equal(t, secret.StringData, map[string]string{
+				".env": "export A=AAA\nexport B=BBB\nexport C=CCC\n",
+				key1:   "Random content",
+				key2:   "Random content 2",
+			})
+		}
 	})
 
 	t.Run("uses labels", func(t *testing.T) {
@@ -122,9 +139,15 @@ func Test__CreateSecret(t *testing.T) {
 			"semaphoreci.com/agent-type": "s1-test",
 		})
 
-		assert.Equal(t, secret.StringData, map[string]string{
-			".env": "export A=AAA\nexport B=BBB\nexport C=CCC\n",
-		})
+		if stdruntime.GOOS == "windows" {
+			assert.Equal(t, secret.StringData, map[string]string{
+				".env": `$env:A = "AAA"\n$env:B = "BBB"\n$env:C = "CCC"\n`,
+			})
+		} else {
+			assert.Equal(t, secret.StringData, map[string]string{
+				".env": "export A=AAA\nexport B=BBB\nexport C=CCC\n",
+			})
+		}
 	})
 }
 

--- a/pkg/kubernetes/client_test.go
+++ b/pkg/kubernetes/client_test.go
@@ -42,15 +42,14 @@ func Test__CreateSecret(t *testing.T) {
 		assert.Equal(t, secret.Name, secretName)
 		assert.Empty(t, secret.Labels)
 
+		var expected string
 		if stdruntime.GOOS == "windows" {
-			assert.Equal(t, secret.StringData, map[string]string{
-				".env": `$env:A = "AAA"\n$env:B = "BBB"\n$env:C = "CCC"\n`,
-			})
+			expected = "$env:A = \"AAA\"\n$env:B = \"BBB\"\n$env:C = \"CCC\"\n"
 		} else {
-			assert.Equal(t, secret.StringData, map[string]string{
-				".env": "export A=AAA\nexport B=BBB\nexport C=CCC\n",
-			})
+			expected = "export A=AAA\nexport B=BBB\nexport C=CCC\n"
 		}
+
+		assert.Equal(t, secret.StringData, map[string]string{".env": expected})
 	})
 
 	t.Run("stores files in secret, with base64-encoded keys", func(t *testing.T) {
@@ -91,19 +90,18 @@ func Test__CreateSecret(t *testing.T) {
 		assert.Equal(t, secret.Name, secretName)
 		assert.Empty(t, secret.Labels)
 
+		var expected string
 		if stdruntime.GOOS == "windows" {
-			assert.Equal(t, secret.StringData, map[string]string{
-				".env": `$env:A = "AAA"\n$env:B = "BBB"\n$env:C = "CCC"\n`,
-				key1:   "Random content",
-				key2:   "Random content 2",
-			})
+			expected = "$env:A = \"AAA\"\n$env:B = \"BBB\"\n$env:C = \"CCC\"\n"
 		} else {
-			assert.Equal(t, secret.StringData, map[string]string{
-				".env": "export A=AAA\nexport B=BBB\nexport C=CCC\n",
-				key1:   "Random content",
-				key2:   "Random content 2",
-			})
+			expected = "export A=AAA\nexport B=BBB\nexport C=CCC\n"
 		}
+
+		assert.Equal(t, secret.StringData, map[string]string{
+			".env": expected,
+			key1:   "Random content",
+			key2:   "Random content 2",
+		})
 	})
 
 	t.Run("uses labels", func(t *testing.T) {
@@ -139,15 +137,14 @@ func Test__CreateSecret(t *testing.T) {
 			"semaphoreci.com/agent-type": "s1-test",
 		})
 
+		var expected string
 		if stdruntime.GOOS == "windows" {
-			assert.Equal(t, secret.StringData, map[string]string{
-				".env": `$env:A = "AAA"\n$env:B = "BBB"\n$env:C = "CCC"\n`,
-			})
+			expected = "$env:A = \"AAA\"\n$env:B = \"BBB\"\n$env:C = \"CCC\"\n"
 		} else {
-			assert.Equal(t, secret.StringData, map[string]string{
-				".env": "export A=AAA\nexport B=BBB\nexport C=CCC\n",
-			})
+			expected = "export A=AAA\nexport B=BBB\nexport C=CCC\n"
 		}
+
+		assert.Equal(t, secret.StringData, map[string]string{".env": expected})
 	})
 }
 

--- a/pkg/shell/env.go
+++ b/pkg/shell/env.go
@@ -127,7 +127,7 @@ func (e *Environment) ToFile(fileName string, callback func(name string)) error 
 	for _, name := range e.Keys() {
 		value, _ := e.Get(name)
 		if runtime.GOOS == "windows" {
-			fileContent += fmt.Sprintf("$env:%s = %q\n", name, escapePowershellQuotes(value))
+			fileContent += fmt.Sprintf("$env:%s = \"%s\"\n", name, escapePowershellQuotes(value))
 		} else {
 			fileContent += fmt.Sprintf("export %s=%s\n", name, shellQuote(value))
 		}
@@ -147,7 +147,8 @@ func (e *Environment) ToFile(fileName string, callback func(name string)) error 
 }
 
 func escapePowershellQuotes(s string) string {
-	return strings.Replace(s, "\"", "`\"", -1)
+	r := strings.Replace(s, "`", "``", -1)
+	return strings.Replace(r, "\"", "`\"", -1)
 }
 
 func shellQuote(s string) string {

--- a/pkg/shell/env.go
+++ b/pkg/shell/env.go
@@ -127,7 +127,7 @@ func (e *Environment) ToFile(fileName string, callback func(name string)) error 
 	for _, name := range e.Keys() {
 		value, _ := e.Get(name)
 		if runtime.GOOS == "windows" {
-			fileContent += fmt.Sprintf("$env:%s = \"%q\"\n", name, powershellQuote(value))
+			fileContent += fmt.Sprintf("$env:%s = %q\n", name, escapePowershellQuotes(value))
 		} else {
 			fileContent += fmt.Sprintf("export %s=%s\n", name, shellQuote(value))
 		}
@@ -146,7 +146,7 @@ func (e *Environment) ToFile(fileName string, callback func(name string)) error 
 	return nil
 }
 
-func powershellQuote(s string) string {
+func escapePowershellQuotes(s string) string {
 	return strings.Replace(s, "\"", "`\"", -1)
 }
 

--- a/pkg/shell/env.go
+++ b/pkg/shell/env.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"regexp"
+	"runtime"
 	"sort"
 	"strings"
 
@@ -125,7 +126,12 @@ func (e *Environment) ToFile(fileName string, callback func(name string)) error 
 	fileContent := ""
 	for _, name := range e.Keys() {
 		value, _ := e.Get(name)
-		fileContent += fmt.Sprintf("export %s=%s\n", name, shellQuote(value))
+		if runtime.GOOS == "windows" {
+			fileContent += fmt.Sprintf("$env:%s = %s\n", name, shellQuote(value))
+		} else {
+			fileContent += fmt.Sprintf("export %s=%s\n", name, shellQuote(value))
+		}
+
 		if callback != nil {
 			callback(name)
 		}

--- a/pkg/shell/env.go
+++ b/pkg/shell/env.go
@@ -127,7 +127,7 @@ func (e *Environment) ToFile(fileName string, callback func(name string)) error 
 	for _, name := range e.Keys() {
 		value, _ := e.Get(name)
 		if runtime.GOOS == "windows" {
-			fileContent += fmt.Sprintf("$env:%s = %s\n", name, shellQuote(value))
+			fileContent += fmt.Sprintf("$env:%s = \"%q\"\n", name, powershellQuote(value))
 		} else {
 			fileContent += fmt.Sprintf("export %s=%s\n", name, shellQuote(value))
 		}
@@ -144,6 +144,10 @@ func (e *Environment) ToFile(fileName string, callback func(name string)) error 
 	}
 
 	return nil
+}
+
+func powershellQuote(s string) string {
+	return strings.Replace(s, "\"", "`\"", -1)
 }
 
 func shellQuote(s string) string {

--- a/pkg/shell/env_test.go
+++ b/pkg/shell/env_test.go
@@ -102,10 +102,6 @@ VAR_C=CCC
 }
 
 func Test__EnvironmentToFile(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("Environment.ToFile() is only used in non-windows")
-	}
-
 	vars := []api.EnvVar{
 		{Name: "Z", Value: base64.StdEncoding.EncodeToString([]byte("ZZZ"))},
 		{Name: "O", Value: base64.StdEncoding.EncodeToString([]byte("OOO"))},
@@ -124,7 +120,12 @@ func Test__EnvironmentToFile(t *testing.T) {
 
 	content, err := ioutil.ReadFile(file.Name())
 	assert.Nil(t, err)
-	assert.Equal(t, string(content), "export O=OOO\nexport QUOTED='This is going to get quoted'\nexport Z=ZZZ\n")
+
+	if runtime.GOOS == "windows" {
+		assert.Equal(t, string(content), "export O=OOO\nexport QUOTED='This is going to get quoted'\nexport Z=ZZZ\n")
+	} else {
+		assert.Equal(t, string(content), `$env:O = "OOO"\n$env:QUOTED = "This is going to get quoted"\n$env:Z = "ZZZ"\n`)
+	}
 
 	file.Close()
 	os.Remove(file.Name())

--- a/pkg/shell/env_test.go
+++ b/pkg/shell/env_test.go
@@ -105,7 +105,9 @@ func Test__EnvironmentToFile(t *testing.T) {
 	vars := []api.EnvVar{
 		{Name: "Z", Value: base64.StdEncoding.EncodeToString([]byte("ZZZ"))},
 		{Name: "O", Value: base64.StdEncoding.EncodeToString([]byte("OOO"))},
-		{Name: "QUOTED", Value: base64.StdEncoding.EncodeToString([]byte("This is going to get quoted"))},
+		{Name: "SPACES_ARE_SINGLE_QUOTED_ON_UNIX", Value: base64.StdEncoding.EncodeToString([]byte("This is going to get quoted"))},
+		{Name: "DOUBLE_QUOTES_ARE_ESCAPED_ON_POWERSHELL", Value: base64.StdEncoding.EncodeToString([]byte("\"This\" is going to get escaped"))},
+		{Name: "BACKTICKS_ARE_ESCAPED_ON_POWERSHELL", Value: base64.StdEncoding.EncodeToString([]byte("`This` is going to get escaped too"))},
 	}
 
 	env, err := CreateEnvironment(vars, []config.HostEnvVar{})
@@ -121,12 +123,24 @@ func Test__EnvironmentToFile(t *testing.T) {
 	content, err := ioutil.ReadFile(file.Name())
 	assert.Nil(t, err)
 
+	var expected string
 	if runtime.GOOS == "windows" {
-		assert.Equal(t, string(content), `$env:O = "OOO"\n$env:QUOTED = "This is going to get quoted"\n$env:Z = "ZZZ"\n`)
+		expected = `$env:BACKTICKS_ARE_ESCAPED_ON_POWERSHELL = "` + "``This``" + ` is going to get escaped too"
+$env:DOUBLE_QUOTES_ARE_ESCAPED_ON_POWERSHELL = "` + "`\"This\"`" + ` is going to get escaped"
+$env:O = "OOO"
+$env:SPACES_ARE_SINGLE_QUOTED_ON_UNIX = "This is going to get quoted"
+$env:Z = "ZZZ"
+`
 	} else {
-		assert.Equal(t, string(content), "export O=OOO\nexport QUOTED='This is going to get quoted'\nexport Z=ZZZ\n")
+		expected = `export BACKTICKS_ARE_ESCAPED_ON_POWERSHELL='` + "`This`" + ` is going to get escaped too'
+export DOUBLE_QUOTES_ARE_ESCAPED_ON_POWERSHELL='"This" is going to get escaped'
+export O=OOO
+export SPACES_ARE_SINGLE_QUOTED_ON_UNIX='This is going to get quoted'
+export Z=ZZZ
+`
 	}
 
+	assert.Equal(t, expected, string(content))
 	file.Close()
 	os.Remove(file.Name())
 }

--- a/pkg/shell/env_test.go
+++ b/pkg/shell/env_test.go
@@ -126,7 +126,7 @@ func Test__EnvironmentToFile(t *testing.T) {
 	var expected string
 	if runtime.GOOS == "windows" {
 		expected = `$env:BACKTICKS_ARE_ESCAPED_ON_POWERSHELL = "` + "``This``" + ` is going to get escaped too"
-$env:DOUBLE_QUOTES_ARE_ESCAPED_ON_POWERSHELL = "` + "`\"This\"`" + ` is going to get escaped"
+$env:DOUBLE_QUOTES_ARE_ESCAPED_ON_POWERSHELL = "` + "`\"This`\"" + ` is going to get escaped"
 $env:O = "OOO"
 $env:SPACES_ARE_SINGLE_QUOTED_ON_UNIX = "This is going to get quoted"
 $env:Z = "ZZZ"

--- a/pkg/shell/env_test.go
+++ b/pkg/shell/env_test.go
@@ -122,9 +122,9 @@ func Test__EnvironmentToFile(t *testing.T) {
 	assert.Nil(t, err)
 
 	if runtime.GOOS == "windows" {
-		assert.Equal(t, string(content), "export O=OOO\nexport QUOTED='This is going to get quoted'\nexport Z=ZZZ\n")
-	} else {
 		assert.Equal(t, string(content), `$env:O = "OOO"\n$env:QUOTED = "This is going to get quoted"\n$env:Z = "ZZZ"\n`)
+	} else {
+		assert.Equal(t, string(content), "export O=OOO\nexport QUOTED='This is going to get quoted'\nexport Z=ZZZ\n")
 	}
 
 	file.Close()


### PR DESCRIPTION
https://github.com/renderedtext/tasks/issues/6922

### Issue

Since we don't need the temporary file containing the environment variables in Windows (no PTY), we are not creating that file. That is an issue for Windows debug jobs which cannot access those values in any way.

### Solution

Create the file for Windows jobs too. The file will be created in the `$env:Temp` directory, usually `C:\Users\<username>\AppData\Local\Temp`. The file is created with a `.ps1` extension and uses the PowerShell format for defining environment variables, so the user can "source" it as well.

Note: `source` is not available in PowerShell, but you can do something like `. <script-name>.ps1`