### PR TITLE
Enable cgroup delegation for semaphore

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -23,6 +23,11 @@ User=$SEMAPHORE_AGENT_INSTALLATION_USER
 WorkingDirectory=$AGENT_INSTALLATION_DIRECTORY
 ExecStart=$AGENT_INSTALLATION_DIRECTORY/agent start --config-file $AGENT_CONFIG_PATH
 Environment=SEMAPHORE_AGENT_LOG_FILE_PATH=$AGENT_INSTALLATION_DIRECTORY/agent.log
+Delegate=yes
+DelegateSubgroup=semaphore
+MemoryAccounting=yes
+CPUAccounting=yes
+TasksAccounting=yes
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
We have a desire at Confluent to create cgroups for some of our tasks.

Ideally, we'd like to create the cgroup within the slice created by systemd -- however that requires the service to be marked as `Delegate=yes`.

Furthermore, cgroups have the "no internal process" constraint (https://docs.kernel.org/admin-guide/cgroup-v2.html).

To create enable subtree_control for child cgroups created, the cgroup created by systemd cannot have any processes. Systemd has the feature `DelegateSubgroup` which will move the systemd process into a nested cgroup to alleviate this constraint.