### PR TITLE
fix: skip post-job hook when executor fails to boot

### DIFF
--- a/pkg/jobs/job.go
+++ b/pkg/jobs/job.go
@@ -358,9 +358,13 @@ func (job *Job) RunWithOptions(options RunOptions) {
 		}
 	}
 
-	// The post-job hook executes after the job's commands finished,
-	// so they do not influence the job's result, just like the epilogues.
-	job.runPostJobHook(options)
+	// The post-job hook executes after the job's commands finished, so it does
+	// not influence the job's result, just like the epilogues. It runs inside
+	// the executor, whose shell is only initialized once the executor boots, so
+	// skip it when the executor never booted.
+	if executorRunning {
+		job.runPostJobHook(options)
+	}
 
 	result, err := job.Teardown(result, epiloguesExecuted, options.CallbackRetryAttempts)
 	if err != nil {

--- a/pkg/jobs/job_test.go
+++ b/pkg/jobs/job_test.go
@@ -15,6 +15,7 @@ import (
 	api "github.com/semaphoreci/agent/pkg/api"
 	"github.com/semaphoreci/agent/pkg/config"
 	eventlogger "github.com/semaphoreci/agent/pkg/eventlogger"
+	executors "github.com/semaphoreci/agent/pkg/executors"
 	testsupport "github.com/semaphoreci/agent/test/support"
 	"github.com/stretchr/testify/assert"
 )
@@ -1431,4 +1432,56 @@ func Test__WaitForLogArchivalStatus(t *testing.T) {
 		status := job.waitForLogArchival(50*time.Millisecond, 10*time.Millisecond)
 		assert.Equal(t, JobLogArchivalStatusFailed, status)
 	})
+}
+
+// stubExecutor lets us drive RunWithOptions without a real shell/container.
+// Prepare() fails (executor never boots); RunCommandWithOptions records whether
+// it was reached, which is our proxy for "the post-job hook was attempted".
+type stubExecutor struct {
+	runCommandCalled bool
+}
+
+func (s *stubExecutor) Prepare() int                                        { return 1 }
+func (s *stubExecutor) Start() int                                          { return 0 }
+func (s *stubExecutor) ExportEnvVars([]api.EnvVar, []config.HostEnvVar) int { return 0 }
+func (s *stubExecutor) InjectFiles([]api.File) int                          { return 0 }
+func (s *stubExecutor) RunCommand(string, bool, string) int                 { return 0 }
+func (s *stubExecutor) RunCommandWithOptions(executors.CommandOptions) int {
+	s.runCommandCalled = true
+	return 0
+}
+func (s *stubExecutor) GetOutputFromCommand(string) (string, int) { return "", 0 }
+func (s *stubExecutor) Stop() int                                 { return 0 }
+func (s *stubExecutor) Cleanup() int                              { return 0 }
+
+func Test__PostJobHookSkippedWhenExecutorFailsToPrepare(t *testing.T) {
+	testLogger, _ := eventlogger.DefaultTestLogger()
+	request := &api.JobRequest{
+		EnvVars:  []api.EnvVar{},
+		Commands: []api.Command{},
+		Logger:   api.Logger{Method: eventlogger.LoggerMethodPush},
+	}
+
+	job, err := NewJobWithOptions(&JobOptions{Request: request, Client: http.DefaultClient, Logger: testLogger})
+	assert.Nil(t, err)
+
+	stub := &stubExecutor{}
+	job.Executor = stub
+
+	hook, _ := testsupport.TempFileWithExtension()
+	defer os.Remove(hook)
+
+	// The hook path must be non-empty, or runPostJobHook returns early and never
+	// reaches the executor — so with it set, the executorRunning guard is what
+	// keeps the hook from running after the failed boot.
+	job.RunWithOptions(RunOptions{
+		EnvVars:               []config.HostEnvVar{},
+		PostJobHookPath:       hook,
+		OnJobFinished:         nil,
+		CallbackRetryAttempts: 1,
+	})
+
+	assert.True(t, job.Finished)
+	assert.False(t, stub.runCommandCalled,
+		"post-job hook must not run when the executor failed to prepare")
 }


### PR DESCRIPTION
## Problem

When a job's executor fails to boot, the agent process crashes with a nil-pointer SIGSEGV instead of failing the job cleanly.

## Root cause

In `Job.RunWithOptions`, the executor is started via `PrepareEnvironment()`. When that fails, `executorRunning` is `false`, so the regular commands and epilogues are correctly skipped — but the post-job hook was called unconditionally afterward:

```go
if executorRunning {
    result = job.RunRegularCommands(options)
    ...
    if !job.Stopped {
        job.handleEpilogues(result)
    }
}

// reached even when executorRunning == false
job.runPostJobHook(options)
```

`runPostJobHook` runs the hook inside the executor (`Executor.RunCommandWithOptions`), which for `DockerComposeExecutor`/`ShellExecutor` calls `e.Shell.NewProcessWithOutput(...)`. `e.Shell` is only assigned once the executor boots successfully, so on a failed boot it is `nil` and the call dereferences a nil pointer — crashing the whole agent process.

## Fix

Gate the post-job hook on `executorRunning`, matching how the epilogues directly above it are already handled. When the executor never booted, the hook is skipped and the job finishes cleanly as failed (with the existing `Failed to prepare executor` / `Executor failed to boot up` log lines).

## Test

Adds `Test__PostJobHookSkippedWhenExecutorFailsToPrepare`: a stub executor whose `Prepare()` fails drives `RunWithOptions` with a post-job hook configured, and the test asserts the hook is never attempted (and the job still finishes). The test fails without the guard and passes with it. The existing `Test__UsePostJobHook` continues to cover the success path.
