### PR TITLE
chore: set repository code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-@lucaspin
+* @DamjanBecirovic @skipi @loadez @dexyk @adbatista


### PR DESCRIPTION
## What

Set the repository code owners to the current maintainer set:

```
* @DamjanBecirovic @skipi @loadez @dexyk @adbatista
```

## Note on the previous file

The file previously contained a single line, `@lucaspin`, with no path pattern. CODEOWNERS entries are `<pattern> <owners...>`, so that line parsed as a pattern with no owners attached and matched nothing — GitHub's CODEOWNERS validator reports no *errors* for it, but no reviewer was requested automatically on recent pull requests, which is consistent with it selecting nobody.

Adding the `*` pattern means the entry now applies to the whole repository, so these owners will be requested automatically on new pull requests.

All five handles were checked against the GitHub API and resolve to existing users.
